### PR TITLE
Use RadialVelocity rather than Redshift

### DIFF
--- a/modules/service/src/main/resources/graphql/itc.graphql
+++ b/modules/service/src/main/resources/graphql/itc.graphql
@@ -172,6 +172,13 @@ enum MagnitudeSystem {
   ERGS_FREQUENCY
 }
 
+# Radial velocity, choose one of the available units
+input RadialVelocityInput {
+  centimetersPerSecond: Long
+  metersPerSecond: BigDecimal
+  kilometersPerSecond: BigDecimal
+}
+
 type Wavelength {
   # Wavelength in pm
   picometers: Int!
@@ -711,8 +718,8 @@ input SpectroscopyModeInput {
   # Target magnitude/system/band.
   magnitude: MagnitudeCreateInput!
 
-  # Target redshift.
-  redshift: BigDecimal!
+  # Target radial velocity
+  radialVelocity: RadialVelocityInput!
 
   # Conditions
   constraints: ConstraintsSetInput!
@@ -745,7 +752,7 @@ input QueryConfigurationAlternativeSearchInput {
   magnitude: MagnitudeCreateInput!
 
   # Target redshift.
-  redshift: BigDecimal!
+  radialVelocity: RadialVelocityInput!
 }
 
 type Result {

--- a/modules/service/src/test/scala/lucuma/itc/service/GraphQLBasicCaseSuite.scala
+++ b/modules/service/src/test/scala/lucuma/itc/service/GraphQLBasicCaseSuite.scala
@@ -27,7 +27,9 @@ class GraphQLBasicCaseSuite extends GraphQLSuite {
               nanometers: 60,
               picometers: 300
             },
-            redshift: 0.1,
+            radialVelocity: {
+              kilometersPerSecond: 1000
+            },
             simultaneousCoverage: {
               picometers: 200
             },
@@ -65,7 +67,7 @@ class GraphQLBasicCaseSuite extends GraphQLSuite {
     )
   }
 
-  test("bad redshift") {
+  test("bad radial velocity") {
     query(
       """
         query {
@@ -73,7 +75,9 @@ class GraphQLBasicCaseSuite extends GraphQLSuite {
             wavelength: {
               picometers: 300
             },
-            redshift: "ddd",
+            radialVelocity: {
+              kilometersPerSecond: ddd
+            },
             simultaneousCoverage: {
               picometers: 200
             },
@@ -106,13 +110,13 @@ class GraphQLBasicCaseSuite extends GraphQLSuite {
         """,
       json"""{
         "errors": [
-          {"message": "Redshift value is not valid StringValue(ddd)"}
+          {"message" : "Radial Velocity value is not valid List((centimetersPerSecond,AbsentValue), (metersPerSecond,AbsentValue), (kilometersPerSecond,UntypedEnumValue(ddd)))"}
         ]
       }"""
     )
   }
 
-  test("bad redshift and wavelength") {
+  test("bad radial velocity and wavelength") {
     query(
       """
         query {
@@ -121,7 +125,9 @@ class GraphQLBasicCaseSuite extends GraphQLSuite {
               picometers: 300,
               nanometers: 200
             },
-            redshift: "0.1",
+            radialVelocity: {
+              kilometersPerSecond: ddd
+            },
             simultaneousCoverage: {
               picometers: 200
             },
@@ -153,7 +159,8 @@ class GraphQLBasicCaseSuite extends GraphQLSuite {
         """,
       json"""{
         "errors": [
-          {"message": "Wavelength defined with multiple units {picometers, nanometers}"}
+          {"message": "Wavelength defined with multiple units {picometers, nanometers}"},
+          {"message" : "Radial Velocity value is not valid List((centimetersPerSecond,AbsentValue), (metersPerSecond,AbsentValue), (kilometersPerSecond,UntypedEnumValue(ddd)))"}
         ]
       }"""
     )
@@ -167,7 +174,9 @@ class GraphQLBasicCaseSuite extends GraphQLSuite {
             wavelength: {
               nanometers: 60,
             },
-            redshift: 0.1,
+            radialVelocity: {
+              kilometersPerSecond: 100
+            },
             simultaneousCoverage: {
               nanometers: 200
             },
@@ -240,11 +249,13 @@ class GraphQLBasicCaseSuite extends GraphQLSuite {
             wavelength: {
               nanometers: 60,
             },
-            redshift: 0.1,
             simultaneousCoverage: {
               nanometers: 200
             },
             resolution: 10,
+            radialVelocity: {
+              kilometersPerSecond: 5
+            },
             signalToNoise: 2,
             spatialProfile: {
               sourceType: POINT_SOURCE
@@ -296,7 +307,9 @@ class GraphQLBasicCaseSuite extends GraphQLSuite {
             wavelength: {
               nanometers: 60,
             },
-            redshift: 0.1,
+            radialVelocity: {
+              kilometersPerSecond: 10
+            },
             simultaneousCoverage: {
               nanometers: 200
             },

--- a/modules/service/src/test/scala/lucuma/itc/service/GraphQLSpectroscopySuite.scala
+++ b/modules/service/src/test/scala/lucuma/itc/service/GraphQLSpectroscopySuite.scala
@@ -24,7 +24,9 @@ class GraphQLSpectroscopySuite extends GraphQLSuite {
             wavelength: {
               nanometers: 60,
             },
-            redshift: 0.1,
+            radialVelocity: {
+              kilometersPerSecond: 1000
+            },
             signalToNoise: 2,
             spatialProfile: {
               sourceType: POINT_SOURCE
@@ -172,7 +174,9 @@ class GraphQLSpectroscopySuite extends GraphQLSuite {
               "error" : null,
               "system" : "VEGA"
             },
-            "redshift" : "0.1",
+            "radialVelocity": {
+              "metersPerSecond": 1000
+            },
             "constraints" : {
               "imageQuality" : "POINT_EIGHT",
               "cloudExtinction" : "POINT_FIVE",
@@ -249,7 +253,9 @@ class GraphQLSpectroscopySuite extends GraphQLSuite {
             wavelength: {
               nanometers: 60,
             },
-            redshift: 0.1,
+            radialVelocity: {
+              centimetersPerSecond: 1000
+            },
             signalToNoise: 2,
             spatialProfile: {
               sourceType: POINT_SOURCE
@@ -381,7 +387,9 @@ class GraphQLSpectroscopySuite extends GraphQLSuite {
             wavelength: {
               nanometers: 60,
             },
-            redshift: 0.1,
+            radialVelocity: {
+              metersPerSecond: 1000
+            },
             signalToNoise: 2,
             spatialProfile: {
               sourceType: POINT_SOURCE


### PR DESCRIPTION
ITC takes redshift but the core target model uses Radial Velocity instead. This PR changes the input param of `redshift` to `radialVelocity` and it will do the conversion internally.
This is more consistent with the current core model