### PR TITLE
Redis cache integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ The app needs two environment variable
 * REDISCLOUD_URL which points to the redis server used for caching. e.g.
     REDISCLOUD_URL = "redis://localhost"
 
+# Caching
+ITC calculations are relatively expensive and they are pure (a given input always produces the same output)
+the lucuma ITC server uses redis to store the results linking them from the request parameters to the results
+
+The cache design is optimized to use minimal space given some of the responses (graphs) are fairly large. 
+We are also asuming we'll never need to go inside the cached data to edit the data and we can
+discard items at any moment.
+
+The keys are stored as `itc:prefix:hash` where hash is just the hash of the parameters
+
+A few diferent encodings were tested to reduce size. Here are some measurement
+
+* Plain json: 1441864
+* Compressed json: 589896
+* Boopickle: 262216
+
 ## Long term
 Ideally we'd port the old ITC codebase and integrate it here. This is no small task but an initial
 attempt was started on the `legacy-port` branch

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ The app needs two environment variable
 * REDISCLOUD_URL which points to the redis server used for caching. e.g.
     REDISCLOUD_URL = "redis://localhost"
 
-# Caching
+## Caching
 ITC calculations are relatively expensive and they are pure (a given input always produces the same output)
 the lucuma ITC server uses redis to store the results linking them from the request parameters to the results
 
-The cache design is optimized to use minimal space given some of the responses (graphs) are fairly large. 
+The cache design is optimized to use minimal space given some of the responses (graphs) are fairly large.
 We are also asuming we'll never need to go inside the cached data to edit the data and we can
 discard items at any moment.
 
@@ -37,6 +37,10 @@ A few diferent encodings were tested to reduce size. Here are some measurement
 * Plain json: 1441864
 * Compressed json: 589896
 * Boopickle: 262216
+
+## Cache flushing
+The only reason for the remote values to be stale is if the old itc changes (happens not very often)
+`lucuma-itc` will check every 1h and verify if the itc data has changed. If so it will flush the whole cache
 
 ## Long term
 Ideally we'd port the old ITC codebase and integrate it here. This is no small task but an initial

--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
-# itc-server
+# lucuma-itc
 
 
-This is a version of the `basic-case` repo running with grackle
+This is a graphql server acting as a proxy for the old ocs2-based itc server
 
+# Run
 
-## TODO
- 
-- [ ] Use values rather than buckets for cloud extinction and image quality
-- [ ] Restrict CORS in production
-- [ ] Require auth
+It is possible to run locally using sbt
+```
+   sbt ~service/reStart
+```
+
+note that using sbtn there is no output, see
+
+https://github.com/spray/sbt-revolver/issues/99
+
+## Env
+
+The app needs two environment variable
+* ITC_URL which needs to point to the address where old ocs2-based itc runs. e.g.
+    ITC_URL = "https://itc-server-exp.herokuapp.com/"
+* REDISCLOUD_URL which points to the redis server used for caching. e.g.
+    REDISCLOUD_URL = "redis://localhost"
 
 ## Long term
 Ideally we'd port the old ITC codebase and integrate it here. This is no small task but an initial

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ val gatlingVersion              = "3.8.3"
 val spireVersion                = "0.18.0"
 val redis4CatsVersion           = "1.2.0"
 val pprintVersion               = "0.7.3"
+val kittensVersion              = "3.0.0-M4"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -101,6 +102,7 @@ lazy val core = project
       "com.manyangled" %% "coulomb-units"       % coulombVersion,
       "org.typelevel" %%% "spire"               % spireVersion,
       "org.typelevel" %%% "spire-extras"        % spireVersion,
+      "org.typelevel" %%% "kittens"             % kittensVersion,
       "org.typelevel"  %% "munit-cats-effect-3" % munitCatsEffectVersion % Test,
       "com.lihaoyi"   %%% "pprint"              % pprintVersion          % Test
     )

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ val spireVersion                = "0.18.0"
 val redis4CatsVersion           = "1.2.0"
 val pprintVersion               = "0.7.3"
 val kittensVersion              = "3.0.0-M4"
+val boopickleVersion            = "1.4.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -141,6 +142,7 @@ lazy val service = project
       "eu.timepit"     %% "refined-cats"                  % refinedVersion,
       "dev.profunktor" %% "redis4cats-effects"            % redis4CatsVersion,
       "dev.profunktor" %% "redis4cats-log4cats"           % redis4CatsVersion,
+      "io.suzaku"      %% "boopickle"                     % boopickleVersion,
       "org.typelevel"  %% "munit-cats-effect-3"           % munitCatsEffectVersion % Test
     ),
     buildInfoKeys     := Seq[BuildInfoKey](

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ val munitVersion                = "0.7.29"
 val disciplineMunitVersion      = "1.0.9"
 val gatlingVersion              = "3.8.3"
 val spireVersion                = "0.18.0"
+val redis4CatsVersion           = "1.2.0"
 val pprintVersion               = "0.7.3"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
@@ -45,6 +46,23 @@ addCommandAlias(
 lazy val commonSettings = lucumaGlobalSettings ++ Seq(
   Test / parallelExecution := false // tests run fine in parallel but output is nicer this way
 )
+
+ThisBuild / watchOnTermination := { (action, cmd, times, state) =>
+  val projNames = cmd
+    .split(";")
+    .flatMap(
+      Some(_)
+        .filter(_.contains("/reStart"))
+        .flatMap(_.trim.split("/reStart") match {
+          case Array(projName) => Some(projName)
+          case _               => None
+        })
+    )
+  projNames.foldLeft(state) { (acc, projName) =>
+    val projRef = ProjectRef((ThisBuild / baseDirectory).value, projName)
+    Project.extract(state).runTask(projRef / reStop, state)._1
+  }
+}
 
 // Basic model classes
 lazy val model = crossProject(JVMPlatform, JSPlatform)
@@ -96,27 +114,32 @@ lazy val service = project
   .settings(
     name              := "lucuma-itc-service",
     scalacOptions -= "-Vtype-diffs",
-    reStart / envVars := Map("ITC_URL" -> "https://itc-server-exp.herokuapp.com/"),
+    reStart / envVars := Map(
+      "ITC_URL"        -> "https://itc-server-exp.herokuapp.com/",
+      "REDISCLOUD_URL" -> "redis://localhost"
+    ),
     libraryDependencies ++= Seq(
-      "edu.gemini"    %% "gsp-graphql-core"              % grackleVersion,
-      "edu.gemini"    %% "gsp-graphql-generic"           % grackleVersion,
-      "edu.gemini"    %% "gsp-graphql-circe"             % grackleVersion,
-      "edu.gemini"    %% "lucuma-graphql-routes-grackle" % graphQLRoutesVersion,
-      "org.tpolecat"  %% "natchez-honeycomb"             % natchezVersion,
-      "org.tpolecat"  %% "natchez-log"                   % natchezVersion,
-      "org.tpolecat"  %% "natchez-http4s"                % natcchezHttp4sVersion,
-      "co.fs2"        %% "fs2-core"                      % fs2Version,
-      "edu.gemini"    %% "lucuma-core"                   % lucumaCoreVersion,
-      "org.typelevel" %% "cats-core"                     % catsVersion,
-      "org.typelevel" %% "cats-effect"                   % catsEffectVersion,
-      "is.cir"        %% "ciris"                         % cirisVersion,
-      "org.typelevel" %% "log4cats-slf4j"                % log4catsVersion,
-      "org.slf4j"      % "slf4j-simple"                  % slf4jVersion,
-      "org.http4s"    %% "http4s-core"                   % http4sVersion,
-      "org.http4s"    %% "http4s-ember-server"           % http4sVersion,
-      "eu.timepit"    %% "refined"                       % refinedVersion,
-      "eu.timepit"    %% "refined-cats"                  % refinedVersion,
-      "org.typelevel" %% "munit-cats-effect-3"           % munitCatsEffectVersion % Test
+      "edu.gemini"     %% "gsp-graphql-core"              % grackleVersion,
+      "edu.gemini"     %% "gsp-graphql-generic"           % grackleVersion,
+      "edu.gemini"     %% "gsp-graphql-circe"             % grackleVersion,
+      "edu.gemini"     %% "lucuma-graphql-routes-grackle" % graphQLRoutesVersion,
+      "org.tpolecat"   %% "natchez-honeycomb"             % natchezVersion,
+      "org.tpolecat"   %% "natchez-log"                   % natchezVersion,
+      "org.tpolecat"   %% "natchez-http4s"                % natcchezHttp4sVersion,
+      "co.fs2"         %% "fs2-core"                      % fs2Version,
+      "edu.gemini"     %% "lucuma-core"                   % lucumaCoreVersion,
+      "org.typelevel"  %% "cats-core"                     % catsVersion,
+      "org.typelevel"  %% "cats-effect"                   % catsEffectVersion,
+      "is.cir"         %% "ciris"                         % cirisVersion,
+      "org.typelevel"  %% "log4cats-slf4j"                % log4catsVersion,
+      "org.slf4j"       % "slf4j-simple"                  % slf4jVersion,
+      "org.http4s"     %% "http4s-core"                   % http4sVersion,
+      "org.http4s"     %% "http4s-ember-server"           % http4sVersion,
+      "eu.timepit"     %% "refined"                       % refinedVersion,
+      "eu.timepit"     %% "refined-cats"                  % refinedVersion,
+      "dev.profunktor" %% "redis4cats-effects"            % redis4CatsVersion,
+      "dev.profunktor" %% "redis4cats-log4cats"           % redis4CatsVersion,
+      "org.typelevel"  %% "munit-cats-effect-3"           % munitCatsEffectVersion % Test
     ),
     buildInfoKeys     := Seq[BuildInfoKey](
       scalaVersion,

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1659254610,
-        "narHash": "sha256-ee5W5MLWZ3kdx5hwOUs6trOJit+GeTDfG+Lg3rANKoc=",
+        "lastModified": 1660494700,
+        "narHash": "sha256-OU9ceb6JvwqUVqFYvYOtpNDwJpHgC3z/dy6GRoaiGgM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "67f49b2a3854e8b5e3f9df4422225daa0985f451",
+        "rev": "bc4b4a50c7a105c56f1b712a87818678298deef3",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1659443857,
-        "narHash": "sha256-iZFgtLpUUiUo0mOVTLe5DzOwPIZylbh8snY0PxJStCc=",
+        "lastModified": 1660579530,
+        "narHash": "sha256-KaIX+bY+M27gNBkt/J2EI98jUlPxxAmsO+1lpI7Qag4=",
         "owner": "typelevel",
         "repo": "typelevel-nix",
-        "rev": "c0796868dd0d4872880041a2799f631fe67be7f7",
+        "rev": "323f642c6dfe7d46c1623f429c96cc16ee67bc8f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           imports = [ typelevel-nix.typelevelShell ];
           packages = [
             pkgs.nodePackages.graphqurl
+            pkgs.redis
           ];
           typelevelShell = {
             nodejs.enable = true;

--- a/modules/itc/src/main/scala/lucuma/itc/ItcChart.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/ItcChart.scala
@@ -95,12 +95,3 @@ object ItcSeries:
 case class ItcChart(chartType: ChartType, series: List[ItcSeries]) derives Encoder.AsObject
 
 case class ItcChartGroup(charts: NonEmptyList[ItcChart]) derives Encoder.AsObject
-
-object redis:
-  given Encoder[ItcSeries]       =
-    Encoder.forProduct3("title", "dataType", "data")(s => (s.title, s.seriesType, s.data))
-  given Decoder[ItcSeries]       = Decoder.forProduct3("title", "seriesType", "data")(ItcSeries.apply)
-  given Decoder[ItcChart]        = deriveDecoder
-  given Decoder[ItcChartGroup]   = deriveDecoder
-  given Decoder[Itc.GraphResult] = deriveDecoder
-  given Encoder[Itc.GraphResult] = deriveEncoder

--- a/modules/itc/src/main/scala/lucuma/itc/ItcChart.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/ItcChart.scala
@@ -82,9 +82,9 @@ case class ItcSeries private (
 ) derives Encoder.AsObject
 
 object ItcSeries:
-  def apply(title: String, dataType: SeriesDataType, data: List[(Double, Double)]): ItcSeries =
+  def apply(title: String, seriesType: SeriesDataType, data: List[(Double, Double)]): ItcSeries =
     ItcSeries(title,
-              dataType,
+              seriesType,
               data,
               data.map(_._1),
               data.map(_._2),
@@ -95,3 +95,12 @@ object ItcSeries:
 case class ItcChart(chartType: ChartType, series: List[ItcSeries]) derives Encoder.AsObject
 
 case class ItcChartGroup(charts: NonEmptyList[ItcChart]) derives Encoder.AsObject
+
+object redis:
+  given Encoder[ItcSeries]       =
+    Encoder.forProduct3("title", "dataType", "data")(s => (s.title, s.seriesType, s.data))
+  given Decoder[ItcSeries]       = Decoder.forProduct3("title", "seriesType", "data")(ItcSeries.apply)
+  given Decoder[ItcChart]        = deriveDecoder
+  given Decoder[ItcChartGroup]   = deriveDecoder
+  given Decoder[Itc.GraphResult] = deriveDecoder
+  given Encoder[Itc.GraphResult] = deriveEncoder

--- a/modules/itc/src/main/scala/lucuma/itc/params.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/params.scala
@@ -3,6 +3,8 @@
 
 package lucuma.itc
 
+import cats.Hash
+import cats.derived.*
 import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.*
@@ -12,6 +14,7 @@ import lucuma.core.enums._
 import lucuma.core.math.Wavelength
 import lucuma.itc.search.ObservingMode.Spectroscopy._
 import lucuma.itc.search.*
+import lucuma.itc.search.hashes.*
 
 import java.math.RoundingMode
 import scala.concurrent.duration.FiniteDuration
@@ -38,4 +41,4 @@ case class ItcObservingConditions(
   wv:      WaterVapor,
   sb:      SkyBackground,
   airmass: Double
-)
+) derives Hash

--- a/modules/itc/src/main/scala/lucuma/itc/search/ObservingMode.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/search/ObservingMode.scala
@@ -3,6 +3,8 @@
 
 package lucuma.itc.search
 
+import cats.Hash
+import cats.derived.*
 import io.circe.*
 import io.circe.syntax.*
 import lucuma.core.enums._
@@ -13,6 +15,7 @@ import lucuma.itc.GmosNITCParams
 import lucuma.itc.GmosSITCParams
 import lucuma.itc.encoders.given
 import lucuma.itc.search.syntax.*
+import lucuma.itc.search.hashes.given
 import spire.math.Rational
 
 case class GmosNorthFpuParam(
@@ -36,7 +39,7 @@ sealed trait ObservingMode {
 
 object ObservingMode {
 
-  sealed trait Spectroscopy extends ObservingMode {
+  sealed trait Spectroscopy extends ObservingMode derives Hash {
     def λ: Wavelength
     def resolution: Rational
     def coverage: Coverage
@@ -48,7 +51,7 @@ object ObservingMode {
       case gs: GmosSouth => gs.asJson
     }
 
-    sealed trait GmosSpectroscopy extends Spectroscopy {
+    sealed trait GmosSpectroscopy extends Spectroscopy derives Hash {
       def isIfu: Boolean
 
       def analysisMethod: ItcObservationDetails.AnalysisMethod =
@@ -68,7 +71,7 @@ object ObservingMode {
       disperser: GmosNorthGrating,
       fpu:       GmosNorthFpuParam,
       filter:    Option[GmosNorthFilter]
-    ) extends GmosSpectroscopy {
+    ) extends GmosSpectroscopy derives Hash {
       val isIfu = fpu.isIfu
 
       val instrument: Instrument =
@@ -95,7 +98,7 @@ object ObservingMode {
       disperser: GmosSouthGrating,
       fpu:       GmosSouthFpuParam,
       filter:    Option[GmosSouthFilter]
-    ) extends GmosSpectroscopy {
+    ) extends GmosSpectroscopy derives Hash {
       val isIfu = fpu.isIfu
 
       val instrument: Instrument =

--- a/modules/itc/src/main/scala/lucuma/itc/search/ObservingMode.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/search/ObservingMode.scala
@@ -14,8 +14,8 @@ import lucuma.core.math.Wavelength
 import lucuma.itc.GmosNITCParams
 import lucuma.itc.GmosSITCParams
 import lucuma.itc.encoders.given
-import lucuma.itc.search.syntax.*
 import lucuma.itc.search.hashes.given
+import lucuma.itc.search.syntax.*
 import spire.math.Rational
 
 case class GmosNorthFpuParam(
@@ -71,7 +71,8 @@ object ObservingMode {
       disperser: GmosNorthGrating,
       fpu:       GmosNorthFpuParam,
       filter:    Option[GmosNorthFilter]
-    ) extends GmosSpectroscopy derives Hash {
+    ) extends GmosSpectroscopy
+        derives Hash {
       val isIfu = fpu.isIfu
 
       val instrument: Instrument =
@@ -98,7 +99,8 @@ object ObservingMode {
       disperser: GmosSouthGrating,
       fpu:       GmosSouthFpuParam,
       filter:    Option[GmosSouthFilter]
-    ) extends GmosSpectroscopy derives Hash {
+    ) extends GmosSpectroscopy
+        derives Hash {
       val isIfu = fpu.isIfu
 
       val instrument: Instrument =

--- a/modules/itc/src/main/scala/lucuma/itc/search/Search.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/search/Search.scala
@@ -19,10 +19,10 @@ import lucuma.itc.given
 
 sealed trait Result:
   def mode: ObservingMode
-  def itc: Itc.Result
+  def itc: Itc.CalcResult
 
 object Result:
-  case class Spectroscopy(mode: ObservingMode.Spectroscopy, itc: Itc.Result)
+  case class Spectroscopy(mode: ObservingMode.Spectroscopy, itc: Itc.CalcResult)
       derives Encoder.AsObject
 
 case class SpectroscopyResults(

--- a/modules/itc/src/main/scala/lucuma/itc/search/TargetProfile.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/search/TargetProfile.scala
@@ -5,10 +5,10 @@ package lucuma.itc.search
 
 import cats.Hash
 import cats.derived.*
-import lucuma.itc.search.hashes.given
 import lucuma.core.enums.Band
 import lucuma.core.math.Redshift
 import lucuma.core.model.SourceProfile
+import lucuma.itc.search.hashes.given
 
 /** Target properties we need to know at phase zero. */
 final case class TargetProfile(

--- a/modules/itc/src/main/scala/lucuma/itc/search/TargetProfile.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/search/TargetProfile.scala
@@ -3,6 +3,9 @@
 
 package lucuma.itc.search
 
+import cats.Hash
+import cats.derived.*
+import lucuma.itc.search.hashes.given
 import lucuma.core.enums.Band
 import lucuma.core.math.Redshift
 import lucuma.core.model.SourceProfile
@@ -12,4 +15,4 @@ final case class TargetProfile(
   sourceProfile: SourceProfile,
   band:          Band,
   redshift:      Redshift
-)
+) derives Hash

--- a/modules/itc/src/main/scala/lucuma/itc/search/hashes.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/search/hashes.scala
@@ -17,7 +17,7 @@ import lucuma.core.util.Enumerated
 
 import java.time.Duration
 
-given hastEnumerated[A: Enumerated]: Hash[A] = Hash.by(summon[Enumerated[A]].tag)
+given hashEnumerated[A: Enumerated]: Hash[A] = Hash.by(summon[Enumerated[A]].tag)
 
 given hashRefined[A: Hash, B](using Validate[A, B]): Hash[A Refined B] =
   Hash.by(_.value)

--- a/modules/itc/src/main/scala/lucuma/itc/search/hashes.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/search/hashes.scala
@@ -5,16 +5,17 @@ package lucuma.itc.search.hashes
 
 import cats.Hash
 import cats.implicits.*
-import lucuma.core.math.Redshift
-import lucuma.core.enums.Band
-import lucuma.core.model.SourceProfile
-import lucuma.core.util.Enumerated
 import eu.timepit.refined._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.Validate
-import java.time.Duration
-import lucuma.core.model.NonNegDuration
+import lucuma.core.enums.Band
+import lucuma.core.math.Redshift
 import lucuma.core.math.Wavelength
+import lucuma.core.model.NonNegDuration
+import lucuma.core.model.SourceProfile
+import lucuma.core.util.Enumerated
+
+import java.time.Duration
 
 given hastEnumerated[A: Enumerated]: Hash[A] = Hash.by(summon[Enumerated[A]].tag)
 

--- a/modules/itc/src/main/scala/lucuma/itc/search/hashes.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/search/hashes.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.itc.search.hashes
+
+import cats.Hash
+import cats.implicits.*
+import lucuma.core.math.Redshift
+import lucuma.core.enums.Band
+import lucuma.core.model.SourceProfile
+import lucuma.core.util.Enumerated
+import eu.timepit.refined._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.api.Validate
+import java.time.Duration
+import lucuma.core.model.NonNegDuration
+import lucuma.core.math.Wavelength
+
+given hastEnumerated[A: Enumerated]: Hash[A] = Hash.by(summon[Enumerated[A]].tag)
+
+given hashRefined[A: Hash, B](using Validate[A, B]): Hash[A Refined B] =
+  Hash.by(_.value)
+
+given Hash[Redshift]       = Hash.by(_.z)
+given Hash[Duration]       = Hash.by(_.getNano())
+given Hash[NonNegDuration] = Hash.by(_.value)
+given Hash[SourceProfile]  = Hash.fromUniversalHashCode[SourceProfile]
+given Hash[Wavelength]     = Hash.by(_.toPicometers.value)

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -18,37 +18,38 @@ import java.nio.charset.Charset
 trait ItcCacheOrRemote extends Version:
   val KeyCharset = Charset.forName("UTF8")
 
+  def cacheOrRemote[F[_]: Monad, A: Hash, B: Pickler](a: A, request: A => F[B])(
+    prefix:                                              String,
+    redis:                                               StringCommands[F, Array[Byte], Array[Byte]]
+  ): F[B] =
+    val hash = Hash[A].hash(a)
+    for
+      fromRedis <- redis.get(s"$prefix:$hash".getBytes(KeyCharset))
+      decoded   <-
+        fromRedis
+          .flatMap(b => Either.catchNonFatal(Unpickle[B].fromBytes(ByteBuffer.wrap(b))).toOption)
+          .pure[F]
+      r         <- decoded.map(_.pure[F]).getOrElse(request(a))
+      _         <-
+        redis
+          .set(s"$prefix:$hash".getBytes(KeyCharset), Pickle.intoBytes(r).compact().array())
+          .whenA(fromRedis.isEmpty)
+    yield r
+
   def graphFromCacheOrRemote[F[_]: Monad](
     request: GraphRequest
   )(itc:     Itc[F], redis: StringCommands[F, Array[Byte], Array[Byte]]): F[Itc.GraphResult] =
-    val hash = Hash[GraphRequest].hash(request)
-    for
-      fromRedis <- redis.get(s"itc:graph:$hash".getBytes(KeyCharset))
-      decoded   <-
-        fromRedis
-          .flatMap(b =>
-            Either.catchNonFatal(Unpickle[Itc.GraphResult].fromBytes(ByteBuffer.wrap(b))).toOption
-          )
-          .pure[F]
-      r         <-
-        decoded
-          .map(_.pure[F])
-          .getOrElse(
-            // Call old itc
-            itc
-              .calculateGraph(
-                request.targetProfile,
-                request.specMode,
-                request.constraints,
-                request.expTime,
-                request.exp
-              )
-          )
-      _         <-
-        redis
-          .set(s"itc:graph:$hash".getBytes(KeyCharset), Pickle.intoBytes(r).compact().array())
-          .whenA(fromRedis.isEmpty)
-    yield r
+    val call = (request: GraphRequest) =>
+      itc
+        .calculateGraph(
+          request.targetProfile,
+          request.specMode,
+          request.constraints,
+          request.expTime,
+          request.exp
+        )
+
+    cacheOrRemote(request, call)("itc:graph:spec", redis)
 
   def versionFromCacheOrRemote[F[_]: Monad](
     environment: ExecutionEnvironment,
@@ -68,3 +69,17 @@ trait ItcCacheOrRemote extends Version:
           .set("itc:version".getBytes(KeyCharset), version.dataVersion.orEmpty.getBytes(KeyCharset))
           .whenA(fromRedis.isEmpty)
     yield version
+
+  def calcFromCacheOrRemote[F[_]: Monad](
+    calcRequest: CalcRequest
+  )(itc:         Itc[F], redis: StringCommands[F, Array[Byte], Array[Byte]]): F[Itc.CalcResultWithVersion] =
+    val call = (calcRequest: CalcRequest) =>
+      itc
+        .calculate(
+          calcRequest.targetProfile,
+          calcRequest.specMode,
+          calcRequest.constraints,
+          calcRequest.signalToNoise.value
+        )
+
+    cacheOrRemote(calcRequest, call)("itc:calc:spec", redis)

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.itc.service
+
+import boopickle.DefaultBasic.*
+import cats._
+import cats.syntax.all._
+import dev.profunktor.redis4cats.algebra.StringCommands
+import lucuma.itc.Itc
+import lucuma.itc.search.ItcVersions
+import lucuma.itc.service.config.ExecutionEnvironment
+import lucuma.itc.service.redis.given
+
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+
+trait ItcCacheOrRemote extends Version:
+  val KeyCharset = Charset.forName("UTF8")
+
+  def graphFromCacheOrRemote[F[_]: Monad](
+    request: GraphRequest
+  )(itc:     Itc[F], redis: StringCommands[F, Array[Byte], Array[Byte]]): F[Itc.GraphResult] =
+    val hash = Hash[GraphRequest].hash(request)
+    for
+      fromRedis <- redis.get(s"itc:graph:$hash".getBytes(KeyCharset))
+      decoded   <-
+        fromRedis
+          .flatMap(b =>
+            Either.catchNonFatal(Unpickle[Itc.GraphResult].fromBytes(ByteBuffer.wrap(b))).toOption
+          )
+          .pure[F]
+      r         <-
+        decoded
+          .map(_.pure[F])
+          .getOrElse(
+            // Call old itc
+            itc
+              .calculateGraph(
+                request.targetProfile,
+                request.specMode,
+                request.constraints,
+                request.expTime,
+                request.exp
+              )
+          )
+      _         <-
+        redis
+          .set(s"itc:graph:$hash".getBytes(KeyCharset), Pickle.intoBytes(r).compact().array())
+          .whenA(fromRedis.isEmpty)
+    yield r
+
+  def versionFromCacheOrRemote[F[_]: Monad](
+    environment: ExecutionEnvironment,
+    redis:       StringCommands[F, Array[Byte], Array[Byte]],
+    itc:         Itc[F]
+  ): F[ItcVersions] =
+    for
+      fromRedis <- redis.get("itc:version".getBytes(KeyCharset))
+      version   <- fromRedis.fold(
+                     itc.itcVersions
+                       .map { r =>
+                         ItcVersions(version(environment).value, r.some)
+                       }
+                   )(v => ItcVersions(version(environment).value, String(v, KeyCharset).some).pure[F])
+      _         <-
+        redis
+          .set("itc:version".getBytes(KeyCharset), version.dataVersion.orEmpty.getBytes(KeyCharset))
+          .whenA(fromRedis.isEmpty)
+    yield version

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration.*
 
 trait ItcCacheOrRemote extends Version:
   val KeyCharset = Charset.forName("UTF8")
-  val TTL        = FiniteDuration(24, HOURS)
+  val TTL        = FiniteDuration(10, DAYS)
 
   def cacheOrRemote[F[_]: Monad, A: Hash, B: Pickler](a: A, request: A => F[B])(
     prefix:                                              String,

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcMappings.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcMappings.scala
@@ -174,7 +174,7 @@ object ItcMapping extends ItcCacheOrRemote with Version with GracklePartials {
         }
     }.map(_.getOrElse(Problem(s"Missing parameters for spectroscopy graph $env").leftIorNec))
 
-  def versions[F[_]: MonadThrow](
+  def versions[F[_]: MonadThrow: Logger](
     environment: ExecutionEnvironment,
     redis:       StringCommands[F, Array[Byte], Array[Byte]],
     itc:         Itc[F]

--- a/modules/service/src/main/scala/lucuma/itc/service/Main.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/Main.scala
@@ -34,6 +34,7 @@ import org.http4s.server.staticcontent._
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import dev.profunktor.redis4cats.data.RedisCodec
 
 // #server
 object Main extends IOApp {
@@ -97,7 +98,7 @@ object Main extends IOApp {
   ): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
     for
       itc     <- ItcImpl.forUri(cfg.itcUrl)
-      redis   <- Redis[F].utf8(cfg.redisUrl.toString)
+      redis   <- Redis[F].simple(cfg.redisUrl.toString, RedisCodec.gzip(RedisCodec.Utf8))
       mapping <- Resource.eval(ItcMapping(cfg.environment, redis, itc))
     yield wsb =>
       // Routes for the ITC GraphQL service

--- a/modules/service/src/main/scala/lucuma/itc/service/Main.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/Main.scala
@@ -98,7 +98,7 @@ object Main extends IOApp {
   ): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
     for
       itc     <- ItcImpl.forUri(cfg.itcUrl)
-      redis   <- Redis[F].simple(cfg.redisUrl.toString, RedisCodec.gzip(RedisCodec.Utf8))
+      redis   <- Redis[F].simple(cfg.redisUrl.toString, RedisCodec.gzip(RedisCodec.Bytes))
       mapping <- Resource.eval(ItcMapping(cfg.environment, redis, itc))
     yield wsb =>
       // Routes for the ITC GraphQL service

--- a/modules/service/src/main/scala/lucuma/itc/service/Main.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/Main.scala
@@ -9,6 +9,7 @@ import cats.effect._
 import cats.syntax.all._
 import com.comcast.ip4s._
 import dev.profunktor.redis4cats.Redis
+import dev.profunktor.redis4cats.data.RedisCodec
 import dev.profunktor.redis4cats.log4cats.*
 import lucuma.graphql.routes.GrackleGraphQLService
 import lucuma.graphql.routes.Routes
@@ -34,7 +35,6 @@ import org.http4s.server.staticcontent._
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import dev.profunktor.redis4cats.data.RedisCodec
 
 // #server
 object Main extends IOApp {

--- a/modules/service/src/main/scala/lucuma/itc/service/config/Config.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/config/Config.scala
@@ -14,6 +14,7 @@ final case class Config(
   environment: ExecutionEnvironment,
   port:        Int,
   itcUrl:      Uri,
+  redisUrl:    Uri,
   honeycomb:   Option[HoneycombConfig]
 )
 
@@ -33,5 +34,8 @@ object Config:
        .or(ConfigValue.default("6060"))
        .as[Int],
      envOrProp("ITC_URL").as[Uri],
+     envOrProp("REDISCLOUD_URL")
+       .or(envOrProp("REDIS_URL"))
+       .as[Uri],
      HoneycombConfig.config.option
     ).parMapN(Config.apply)

--- a/modules/service/src/main/scala/lucuma/itc/service/redis.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/redis.scala
@@ -5,9 +5,9 @@ package lucuma.itc.service.redis
 
 import boopickle.DefaultBasic.*
 import cats.data.NonEmptyList
-import lucuma.core.util.Enumerated
 import eu.timepit.refined.*
 import eu.timepit.refined.api.*
+import lucuma.core.util.Enumerated
 import lucuma.itc.*
 
 given picklerRefined[A: Pickler, B](using Validate[A, B]): Pickler[A Refined B] =
@@ -23,9 +23,7 @@ given picklerRefined[A: Pickler, B](using Validate[A, B]): Pickler[A Refined B] 
   }
 
 given picklerEnumeration[A: Enumerated]: Pickler[A] =
-  transformPickler((a: String) =>
-    Enumerated[A].fromTag(a).getOrElse(sys.error("Cannot unpickle"))
-  )(
+  transformPickler((a: String) => Enumerated[A].fromTag(a).getOrElse(sys.error("Cannot unpickle")))(
     Enumerated[A].tag(_)
   )
 

--- a/modules/service/src/main/scala/lucuma/itc/service/redis.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/redis.scala
@@ -12,6 +12,11 @@ import lucuma.itc.*
 
 import scala.concurrent.duration.*
 
+// --------------------------------------------------
+// Pickler to store results in binary with boopickle
+// The data is further gzipped
+// --------------------------------------------------
+
 given picklerRefined[A: Pickler, B](using Validate[A, B]): Pickler[A Refined B] =
   new Pickler[A Refined B] {
     override def pickle(a: A Refined B)(using state: PickleState): Unit = {

--- a/modules/service/src/main/scala/lucuma/itc/service/redis.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/redis.scala
@@ -24,7 +24,7 @@ given picklerRefined[A: Pickler, B](using Validate[A, B]): Pickler[A Refined B] 
     }
   }
 
-given picklerEnumeration[A: Enumerated]: Pickler[A] =
+given picklerEnumerated[A: Enumerated]: Pickler[A] =
   transformPickler((a: String) => Enumerated[A].fromTag(a).getOrElse(sys.error("Cannot unpickle")))(
     Enumerated[A].tag(_)
   )

--- a/modules/service/src/test/scala/lucuma/itc/service/GraphQLSuite.scala
+++ b/modules/service/src/test/scala/lucuma/itc/service/GraphQLSuite.scala
@@ -135,7 +135,10 @@ trait GraphQLSuite extends munit.CatsEffectSuite:
   val service: IO[HttpRoutes[IO]] =
     for
       wsb <- WebSocketBuilder2[IO]
-      map <- ItcMapping[IO](ExecutionEnvironment.Local, new NoOpRedis[IO, String, String](), itc)
+      map <- ItcMapping[IO](ExecutionEnvironment.Local,
+                            new NoOpRedis[IO, Array[Byte], Array[Byte]](),
+                            itc
+             )
     yield Routes.forService(_ => IO.pure(GrackleGraphQLService(map).some), wsb)
 
   val itcFixture = ResourceSuiteLocalFixture(

--- a/modules/service/src/test/scala/lucuma/itc/service/GraphQLSuite.scala
+++ b/modules/service/src/test/scala/lucuma/itc/service/GraphQLSuite.scala
@@ -96,8 +96,8 @@ trait GraphQLSuite extends munit.CatsEffectSuite:
       observingMode: ObservingMode,
       constraints:   ItcObservingConditions,
       signalToNoise: BigDecimal
-    ): IO[(Option[String], Itc.Result)] =
-      (none, Itc.Result.Success(1.seconds, 10, 10)).pure[IO]
+    ): IO[Itc.CalcResultWithVersion] =
+      Itc.CalcResultWithVersion(Itc.CalcResult.Success(1.seconds, 10, 10)).pure[IO]
 
     def calculateGraph(
       targetProfile: TargetProfile,

--- a/modules/service/src/test/scala/lucuma/itc/service/GraphQLSuite.scala
+++ b/modules/service/src/test/scala/lucuma/itc/service/GraphQLSuite.scala
@@ -3,13 +3,19 @@
 
 package lucuma.itc.service
 
+import cats.Applicative
+import cats.ApplicativeThrow
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.syntax.all._
+import dev.profunktor.redis4cats.algebra.StringCommands
+import dev.profunktor.redis4cats.effects.SetArgs
 import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.numeric.PosLong
 import io.circe.Json
 import io.circe.parser._
+import io.lettuce.core.RedisFuture
+import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands
 import lucuma.core.model.NonNegDuration
 import lucuma.graphql.routes.GrackleGraphQLService
 import lucuma.graphql.routes.Routes
@@ -36,6 +42,51 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import java.time.Duration
 import scala.concurrent.duration._
 
+class NoOpRedis[F[_]: ApplicativeThrow, K, V] extends StringCommands[F, K, V] {
+
+  override def unsafe[A](f: RedisClusterAsyncCommands[K, V] => RedisFuture[A]): F[A] =
+    ApplicativeThrow[F].raiseError(new RuntimeException("unsuppported"))
+
+  override def getSet(key: K, value: V): F[Option[V]] = none.pure[F]
+
+  override def get(key: K): F[Option[V]] = none.pure[F]
+
+  override def mSetNx(keyValues: Map[K, V]): F[Boolean] = true.pure[F]
+
+  override def getRange(key: K, start: Long, end: Long): F[Option[V]] = none.pure[F]
+
+  override def mGet(keys: Set[K]): F[Map[K, V]] = Map.empty.pure[F]
+
+  override def unsafeSync[A](f: RedisClusterAsyncCommands[K, V] => A): F[A] =
+    ApplicativeThrow[F].raiseError(new RuntimeException("unsuppported"))
+
+  override def incr(key: K): F[Long] = 1L.pure[F]
+
+  override def decrBy(key: K, amount: Long): F[Long] = (amount - 1).pure[F]
+
+  override def strLen(key: K): F[Option[Long]] = none.pure[F]
+
+  override def mSet(keyValues: Map[K, V]): F[Unit] = Applicative[F].unit
+
+  override def decr(key: K): F[Long] = 1L.pure[F]
+
+  override def incrByFloat(key: K, amount: Double): F[Double] = (amount + 1).pure[F]
+
+  override def set(key: K, value: V, setArgs: SetArgs): F[Boolean] = true.pure[F]
+
+  override def set(key: K, value: V): F[Unit] = Applicative[F].unit
+
+  override def setNx(key: K, value: V): F[Boolean] = true.pure[F]
+
+  override def setRange(key: K, value: V, offset: Long): F[Unit] = Applicative[F].unit
+
+  override def setEx(key: K, value: V, expiresIn: FiniteDuration): F[Unit] = Applicative[F].unit
+
+  override def incrBy(key: K, amount: Long): F[Long] = (amount + 1).pure[F]
+
+  override def append(key: K, value: V): F[Unit] = Applicative[F].unit
+
+}
 trait GraphQLSuite extends munit.CatsEffectSuite:
   given Logger[IO] = Slf4jLogger.getLogger[IO]
 
@@ -84,7 +135,7 @@ trait GraphQLSuite extends munit.CatsEffectSuite:
   val service: IO[HttpRoutes[IO]] =
     for
       wsb <- WebSocketBuilder2[IO]
-      map <- ItcMapping[IO](ExecutionEnvironment.Local, itc)
+      map <- ItcMapping[IO](ExecutionEnvironment.Local, new NoOpRedis[IO, String, String](), itc)
     yield Routes.forService(_ => IO.pure(GrackleGraphQLService(map).some), wsb)
 
   val itcFixture = ResourceSuiteLocalFixture(


### PR DESCRIPTION
This PR uses redis to greatly improve performance by reducing calls to upstream old itc storing the values in redis instead

Features included:
* Store computation results on redis and use them for subsequent results
* Auto flush cache in case itc data changes
* Setup HTTP caching at the headers level
* Other internal improvements