### PR TITLE
Add max signal per ccd

### DIFF
--- a/modules/itc/src/main/scala/lucuma/itc/ItcCcd.scala
+++ b/modules/itc/src/main/scala/lucuma/itc/ItcCcd.scala
@@ -11,7 +11,9 @@ import lucuma.itc.encoders.given
 
 case class ItcCcd(
   singleSNRatio:                 Double,          // the final SN ratio for a single image
+  maxSingleSNRatio:              Double,          // the max single SN ratio for a single image/ccd
   totalSNRatio:                  Double,          // the total SN ratio for all images
+  maxTotalSNRatio:               Double,          // the max final SN ratio for all images/ccd
   wavelengthForMaxTotalSNRatio:  Wavelength,      // Wavelength where we get the max total SN
   wavelengthForMaxSingleSNRatio: Wavelength,      // Wavelength where we get the max single SN
   peakPixelFlux:                 Double,          // the highest e- count for all pixels on the CCD

--- a/modules/service/src/main/resources/graphql/itc.graphql
+++ b/modules/service/src/main/resources/graphql/itc.graphql
@@ -4887,14 +4887,20 @@ type ItcCcd {
   # the final SN ratio for a single image
   singleSNRatio: BigDecimal!
 
+  # Wavelength where we get the max singl SN
+  wavelengthForMaxSingleSNRatio: Wavelength!
+
+  # the max single SN ratio for this ccd
+  maxSingleSNRatio:  BigDecimal!
+
   # the total SN ratio for all images
   totalSNRatio:  BigDecimal!
 
   # Wavelength where we get the max total SN
   wavelengthForMaxTotalSNRatio: Wavelength!
 
-  # Wavelength where we get the max singl SN
-  wavelengthForMaxSingleSNRatio: Wavelength!
+  # the max final SN ratio for this ccd
+  maxTotalSNRatio:  BigDecimal!
 
   # the highest e- count for all pixels on the CCD
   peakPixelFlux: BigDecimal!

--- a/modules/service/src/main/scala/lucuma/itc/service/syntax/ItcSyntax.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/syntax/ItcSyntax.scala
@@ -73,7 +73,9 @@ trait ItcChartSyntax:
       figures.ccd.fold(ccd)(c =>
         ccd.copy(
           singleSNRatio = roundToSignificantFigures(ccd.singleSNRatio, c.value),
+          maxSingleSNRatio = roundToSignificantFigures(ccd.maxSingleSNRatio, c.value),
           totalSNRatio = roundToSignificantFigures(ccd.totalSNRatio, c.value),
+          maxTotalSNRatio = roundToSignificantFigures(ccd.maxTotalSNRatio, c.value),
           peakPixelFlux = roundToSignificantFigures(ccd.peakPixelFlux, c.value),
           wellDepth = roundToSignificantFigures(ccd.wellDepth, c.value),
           ampGain = roundToSignificantFigures(ccd.ampGain, c.value)

--- a/modules/service/src/test/scala/lucuma/itc/service/GraphQLSuite.scala
+++ b/modules/service/src/test/scala/lucuma/itc/service/GraphQLSuite.scala
@@ -113,6 +113,8 @@ trait GraphQLSuite extends munit.CatsEffectSuite:
           "1",
           NonEmptyList.of(
             ItcCcd(1,
+                   1,
+                   2,
                    2,
                    Wavelength.fromNanometers(1001).get,
                    Wavelength.fromNanometers(1001).get,


### PR DESCRIPTION
To my surprise the total/single SN reported on each ccd is global
This PR adds fields to export the values per ccd independently