### PR TITLE
versions query

### DIFF
--- a/modules/client/src/main/scala/lucuma/itc/client/ItcClient.scala
+++ b/modules/client/src/main/scala/lucuma/itc/client/ItcClient.scala
@@ -27,12 +27,14 @@ import org.typelevel.log4cats.Logger
  */
 trait ItcClient[F[_]] {
 
-  // TODO: chart, version, etc.
+  // TODO: chart
 
   def spectroscopy(
     input:    SpectroscopyModeInput,
     useCache: Boolean = true
   ): F[Either[Throwable, SpectroscopyResult]]
+
+  def versions: F[Either[Throwable, ItcVersions]]
 
 }
 
@@ -75,6 +77,9 @@ object ItcClient {
               _    <- Logger[F].info(s"ITC Result (${cval.fold("remote")(_ => "cached")}):\n$res")
             } yield res
           }
+
+          override val versions: F[Either[Throwable, ItcVersions]] =
+            httpClient.use(_.request(VersionsQuery)).attempt
 
         }
       }

--- a/modules/client/src/main/scala/lucuma/itc/client/ItcClient.scala
+++ b/modules/client/src/main/scala/lucuma/itc/client/ItcClient.scala
@@ -4,6 +4,7 @@
 package lucuma.itc.client
 
 import cats.Applicative
+import cats.ApplicativeError
 import cats.effect.Async
 import cats.effect.Ref
 import cats.effect.Resource
@@ -32,9 +33,9 @@ trait ItcClient[F[_]] {
   def spectroscopy(
     input:    SpectroscopyModeInput,
     useCache: Boolean = true
-  ): F[Either[Throwable, SpectroscopyResult]]
+  ): F[SpectroscopyResult]
 
-  def versions: F[Either[Throwable, ItcVersions]]
+  def versions: F[ItcVersions]
 
 }
 
@@ -45,10 +46,9 @@ object ItcClient {
     client: Client[F]
   ): F[ItcClient[F]] =
     Ref
-      .of[F, Map[SpectroscopyModeInput, Either[Throwable, SpectroscopyResult]]](Map.empty)
+      .of[F, Map[SpectroscopyModeInput, SpectroscopyResult]](Map.empty)
       .map { cache =>
-        // TODO: Cache contains failed results and is not flushed until the next server restart.
-        // TOOD: Likely we don't want to cache failures and should flush at least when the version changes.
+        // TOOD: Likely we should flush at least when the version changes.
 
         new ItcClient[F] {
           val httpClient: Resource[F, TransactionalClient[F, Unit]] =
@@ -59,15 +59,15 @@ object ItcClient {
           override def spectroscopy(
             input:    SpectroscopyModeInput,
             useCache: Boolean = true
-          ): F[Either[Throwable, SpectroscopyResult]] = {
+          ): F[SpectroscopyResult] = {
 
-            val callAndCache: F[Either[Throwable, SpectroscopyResult]] =
+            val callAndCache: F[SpectroscopyResult] =
               for {
-                r <- httpClient.use(_.request(SpectroscopyQuery)(input)).attempt
-                rʹ = r.flatMap(
-                       _.headOption.toRight(new RuntimeException("No results returned by ITC."))
-                     )
-                _ <- cache.update(_ + (input -> rʹ))
+                r  <- httpClient.use(_.request(SpectroscopyQuery)(input))
+                rʹ <-
+                  ApplicativeError[F, Throwable]
+                    .fromOption(r.headOption, new RuntimeException("No results returned by ITC."))
+                _  <- cache.update(_ + (input -> rʹ))
               } yield rʹ
 
             for {
@@ -78,8 +78,8 @@ object ItcClient {
             } yield res
           }
 
-          override val versions: F[Either[Throwable, ItcVersions]] =
-            httpClient.use(_.request(VersionsQuery)).attempt
+          override val versions: F[ItcVersions] =
+            httpClient.use(_.request(VersionsQuery))
 
         }
       }

--- a/modules/client/src/main/scala/lucuma/itc/client/ItcVersions.scala
+++ b/modules/client/src/main/scala/lucuma/itc/client/ItcVersions.scala
@@ -9,7 +9,6 @@ import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.HCursor
 
-
 // ITC versions reported by the server.  You cannot infer ordering from the
 // information but they can be used for equality comparisons.
 final case class ItcVersions(

--- a/modules/client/src/main/scala/lucuma/itc/client/ItcVersions.scala
+++ b/modules/client/src/main/scala/lucuma/itc/client/ItcVersions.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.itc.client
+
+import cats.Eq
+import cats.syntax.eq.*
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.HCursor
+
+
+// ITC versions reported by the server.  You cannot infer ordering from the
+// information but they can be used for equality comparisons.
+final case class ItcVersions(
+  server: String,
+  data:   Option[String]
+)
+
+object ItcVersions {
+
+  given Decoder[ItcVersions] with
+    def apply(c: HCursor): Decoder.Result[ItcVersions] =
+      for {
+        s <- c.downField("serverVersion").as[String]
+        d <- c.downField("dataVersion").as[Option[String]]
+      } yield ItcVersions(s, d)
+
+  given Eq[ItcVersions] with
+    def eqv(x: ItcVersions, y: ItcVersions): Boolean =
+      (x.server === y.server) && (x.data === y.data)
+
+}

--- a/modules/client/src/main/scala/lucuma/itc/client/SpectroscopyResult.scala
+++ b/modules/client/src/main/scala/lucuma/itc/client/SpectroscopyResult.scala
@@ -11,9 +11,8 @@ import io.circe.DecodingFailure
 import io.circe.HCursor
 
 final case class SpectroscopyResult(
-  serverVersion: String,
-  dataVersion:   Option[String],
-  result:        Option[ItcResult]
+  versions: ItcVersions,
+  result:   Option[ItcResult]
 )
 
 object SpectroscopyResult {
@@ -21,15 +20,13 @@ object SpectroscopyResult {
   given Decoder[SpectroscopyResult] with
     def apply(c: HCursor): Decoder.Result[SpectroscopyResult] =
       for {
-        s <- c.downField("serverVersion").as[String]
-        d <- c.downField("dataVersion").as[Option[String]]
+        v <- c.as[ItcVersions]
         r <- c.downField("results").downArray.downField("itc").success.traverse(_.as[ItcResult])
-      } yield SpectroscopyResult(s, d, r)
+      } yield SpectroscopyResult(v, r)
 
   given Eq[SpectroscopyResult] with
     def eqv(x: SpectroscopyResult, y: SpectroscopyResult): Boolean =
-      x.serverVersion === y.serverVersion &&
-        x.dataVersion === y.dataVersion &&
+      x.versions === y.versions &&
         x.result === y.result
 
 }

--- a/modules/client/src/main/scala/lucuma/itc/client/VersionsQuery.scala
+++ b/modules/client/src/main/scala/lucuma/itc/client/VersionsQuery.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.itc.client
+
+import cats.syntax.traverse.*
+import clue.GraphQLOperation
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.HCursor
+import io.circe.Json
+
+object VersionsQuery extends GraphQLOperation[Unit] {
+
+  type Data      = ItcVersions
+  type Variables = Unit
+
+  override val document: String =
+    """
+      query Versions {
+        versions {
+          serverVersion
+          dataVersion
+        }
+      }
+    """
+
+  override val varEncoder: Encoder[Unit] =
+    Encoder[Unit]
+
+  override val dataDecoder: Decoder[ItcVersions] =
+    (c: HCursor) => c.downField("versions").as[ItcVersions]
+
+}

--- a/modules/tests/src/test/scala/lucuma/itc/client/ClientSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/client/ClientSuite.scala
@@ -66,7 +66,7 @@ trait ClientSuite extends CatsEffectSuite {
     expected: Either[String, SpectroscopyResult]
   ): IO[Unit] =
     itcClient.use {
-      _.spectroscopy(in)
+      _.spectroscopy(in).attempt
         .map(_.leftMap(_.getMessage))
         .assertEquals(expected)
     }
@@ -75,7 +75,7 @@ trait ClientSuite extends CatsEffectSuite {
     expected: Either[String, ItcVersions]
   ): IO[Unit] =
     itcClient.use {
-      _.versions
+      _.versions.attempt
         .map(_.leftMap(_.getMessage))
         .assertEquals(expected)
     }

--- a/modules/tests/src/test/scala/lucuma/itc/client/ClientSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/client/ClientSuite.scala
@@ -71,4 +71,12 @@ trait ClientSuite extends CatsEffectSuite {
         .assertEquals(expected)
     }
 
+  def versions(
+    expected: Either[String, ItcVersions]
+  ): IO[Unit] =
+    itcClient.use {
+      _.versions
+        .map(_.leftMap(_.getMessage))
+        .assertEquals(expected)
+    }
 }

--- a/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
@@ -33,14 +33,16 @@ import java.time.Duration
 import java.time.Instant
 import scala.collection.immutable.SortedMap
 
-class SpectroscopySuite extends ClientSuite {
+class WiringSuite extends ClientSuite {
 
-  test("ItcClient basic wiring and sanity check") {
+  test("ItcClient spectroscopy basic wiring and sanity check") {
     spectroscopy(
-      SpectroscopySuite.Input,
+      WiringSuite.Input,
       SpectroscopyResult(
-        versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
-        None,
+        ItcVersions(
+          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          None
+        ),
         ItcResult
           .Success(
             NonNegDuration.unsafeFrom(Duration.parse("PT1S")),
@@ -52,9 +54,18 @@ class SpectroscopySuite extends ClientSuite {
     )
   }
 
+  test("ItcClient versions") {
+    versions(
+      ItcVersions(
+        versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+        Some("versionToken")
+      ).asRight
+    )
+  }
+
 }
 
-object SpectroscopySuite {
+object WiringSuite {
 
   val Input: SpectroscopyModeInput =
     SpectroscopyModeInput(


### PR DESCRIPTION
Adds `versions` to the the ITC client, saves the `attempt` for the caller to do if desired.  Am I right that the versions should be treated as opaque data that we can compare for equality but not ordered or used for anything else?