### PR TITLE
Calculate signal at a wavelength in the graphs

### DIFF
--- a/modules/client/shared/src/main/scala/lucuma/itc/client/ITCQueries.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/ITCQueries.scala
@@ -133,6 +133,8 @@ object SpectroscopyGraphQuery
             }
           }
         }
+        peakSNRatio
+        atWavelengthSNRatio
       }
     }
   """

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/OptimizedSpectroscopyGraphInput.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/OptimizedSpectroscopyGraphInput.scala
@@ -25,6 +25,7 @@ import lucuma.itc.encoders.given
 
 final case class OptimizedSpectroscopyGraphInput(
   wavelength:         Wavelength,
+  signalToNoiseAt:    Option[Wavelength],
   exposureTime:       TimeSpan,
   exposures:          PosInt,
   sourceProfile:      SourceProfile,
@@ -41,6 +42,9 @@ object OptimizedSpectroscopyGraphInput {
   given Encoder.AsObject[OptimizedSpectroscopyGraphInput] = a =>
     JsonObject(
       "wavelength"         -> Json.obj("picometers" -> a.wavelength.toPicometers.value.asJson),
+      "signalToNoiseAt"    -> a.signalToNoiseAt
+        .map(w => Json.obj("picometers" -> w.toPicometers.value.asJson))
+        .asJson,
       "exposureTime"       -> Json.obj("microseconds" -> a.exposureTime.asJson),
       "exposures"          -> a.exposures.value.asJson,
       "sourceProfile"      -> a.sourceProfile.asJson,
@@ -59,6 +63,7 @@ object OptimizedSpectroscopyGraphInput {
     Eq.by { a =>
       (
         a.wavelength,
+        a.signalToNoiseAt,
         a.exposureTime,
         a.exposures,
         a.sourceProfile,

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/OptimizedSpectroscopyGraphResult.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/OptimizedSpectroscopyGraphResult.scala
@@ -11,6 +11,7 @@ import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.Encoder
 import io.circe.HCursor
+import lucuma.core.math.SignalToNoise
 import lucuma.itc.IntegrationTime
 import lucuma.itc.*
 
@@ -27,8 +28,10 @@ case class OptimizedChartResult(chartType: ChartType, series: List[OptimizedSeri
     derives Encoder.AsObject
 
 case class OptimizedSpectroscopyGraphResult(
-  serverVersion: String,
-  dataVersion:   String,
-  ccds:          NonEmptyList[ItcCcd],
-  charts:        NonEmptyList[OptimizedChartResult]
+  serverVersion:       String,
+  dataVersion:         String,
+  ccds:                NonEmptyList[ItcCcd],
+  charts:              NonEmptyList[OptimizedChartResult],
+  peakSNRatio:         SignalToNoise,
+  atWavelengthSNRatio: Option[SignalToNoise]
 ) derives Encoder.AsObject

--- a/modules/model/src/main/scala/lucuma/itc/ItcChart.scala
+++ b/modules/model/src/main/scala/lucuma/itc/ItcChart.scala
@@ -17,6 +17,7 @@ import io.circe.Json
 import io.circe.generic.semiauto.*
 import io.circe.refined.*
 import lucuma.core.enums.*
+import lucuma.core.math.SignalToNoise
 import lucuma.core.syntax.string.*
 import lucuma.core.util.Enumerated
 import lucuma.itc.math.*
@@ -76,8 +77,10 @@ case class ItcChart(chartType: ChartType, series: List[ItcSeries]) derives Encod
 case class ItcChartGroup(charts: NonEmptyList[ItcChart]) derives Encoder.AsObject
 
 case class SpectroscopyGraphResult(
-  serverVersion: String,
-  dataVersion:   String,
-  ccds:          NonEmptyList[ItcCcd],
-  charts:        NonEmptyList[ItcChart]
+  serverVersion:       String,
+  dataVersion:         String,
+  ccds:                NonEmptyList[ItcCcd],
+  charts:              NonEmptyList[ItcChart],
+  peakSNRatio:         SignalToNoise,
+  atWavelengthSNRatio: Option[SignalToNoise]
 ) derives Encoder.AsObject

--- a/modules/service/src/main/resources/graphql/itc.graphql
+++ b/modules/service/src/main/resources/graphql/itc.graphql
@@ -4813,6 +4813,9 @@ input OptimizedSpectroscopyGraphInput {
   # Observing wavelength.
   wavelength: WavelengthInput!
 
+  # Wavelength at which to measure Signal to Noise
+  signalToNoiseAt: WavelengthInput
+
   # Exposure time duration
   exposureTime: NonNegDurationInput!
 
@@ -5047,6 +5050,11 @@ type OptimizedSpectroscopyGraphResult {
   # Chart data
   charts: [ItcChart!]!
 
+  # Peak SN Ratio
+  peakSNRatio: SignalToNoise!
+
+  # SN Ratio at the requested wavelength if passed along
+  atWavelengthSNRatio: SignalToNoise
 }
 
 """Calculation result types"""

--- a/modules/service/src/main/scala/lucuma/itc/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/Itc.scala
@@ -37,11 +37,12 @@ trait Itc[F[_]]:
    * Retrieve the graph data for the given mode and exposureTime and exposures
    */
   def calculateGraph(
-    targetProfile: TargetProfile,
-    observingMode: ObservingMode,
-    constraints:   ItcObservingConditions,
-    exposureTime:  NonNegDuration,
-    exposures:     PosLong
+    targetProfile:   TargetProfile,
+    observingMode:   ObservingMode,
+    constraints:     ItcObservingConditions,
+    exposureTime:    NonNegDuration,
+    exposures:       PosLong,
+    signalToNoiseAt: Option[Wavelength]
   ): F[GraphResult]
 
   /**

--- a/modules/service/src/main/scala/lucuma/itc/ItcImpl.scala
+++ b/modules/service/src/main/scala/lucuma/itc/ItcImpl.scala
@@ -123,11 +123,12 @@ object ItcImpl {
         }
 
       def calculateGraph(
-        targetProfile: TargetProfile,
-        observingMode: ObservingMode,
-        constraints:   ItcObservingConditions,
-        exposureTime:  NonNegDuration,
-        exposures:     PosLong
+        targetProfile:   TargetProfile,
+        observingMode:   ObservingMode,
+        constraints:     ItcObservingConditions,
+        exposureTime:    NonNegDuration,
+        exposures:       PosLong,
+        signalToNoiseAt: Option[Wavelength]
       ): F[GraphResult] =
         observingMode match
           case _: ObservingMode.SpectroscopyMode =>
@@ -136,7 +137,8 @@ object ItcImpl {
               observingMode,
               constraints,
               BigDecimal(exposureTime.value.toMillis).withUnit[Millisecond].toUnit[Second],
-              exposures.value
+              exposures.value,
+              signalToNoiseAt
             )
           case _: ObservingMode.ImagingMode      =>
             MonadThrow[F].raiseError(
@@ -242,10 +244,11 @@ object ItcImpl {
         observingMode:    ObservingMode,
         constraints:      ItcObservingConditions,
         exposureDuration: Quantity[BigDecimal, Second],
-        exposures:        Long
+        exposures:        Long,
+        signalToNoiseAt:  Option[Wavelength]
       ): F[GraphResult] =
         itcGraph(targetProfile, observingMode, constraints, exposureDuration, exposures).map { r =>
-          GraphResult.fromLegacy(r.ccds, r.groups)
+          GraphResult.fromLegacy(r.ccds, r.groups, signalToNoiseAt)
         }
 
       /**

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -83,7 +83,8 @@ trait ItcCacheOrRemote extends Version:
             request.specMode,
             request.constraints,
             request.expTime,
-            request.exp
+            request.exp,
+            request.signalToNoiseAt
         )
 
   /**

--- a/modules/service/src/main/scala/lucuma/itc/service/syntax/ItcSyntax.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/syntax/ItcSyntax.scala
@@ -6,6 +6,7 @@ package lucuma.itc.service.syntax
 import cats.data._
 import edu.gemini.grackle.Problem
 import edu.gemini.grackle.Query.Environment
+import lucuma.core.math.SignalToNoise
 import lucuma.itc.ItcCcd
 import lucuma.itc.ItcChart
 import lucuma.itc.ItcChartGroup
@@ -63,6 +64,17 @@ trait ItcChartSyntax:
   extension (chart: ItcChart)
     def adjustSignificantFigures(figures: SignificantFigures): ItcChart =
       chart.copy(series = chart.series.map(_.adjustSignificantFigures(figures)))
+
+  extension (sn: SignalToNoise)
+    def adjustSignificantFigures(figures: SignificantFigures): SignalToNoise =
+      figures.ccd match
+        case Some(v) =>
+          SignalToNoise.FromBigDecimalRounding
+            .getOption(
+              roundToSignificantFigures(sn.toBigDecimal, v.value)
+            )
+            .getOrElse(sn)
+        case _       => sn
 
   extension (group: ItcChartGroup)
     def adjustSignificantFigures(figures: SignificantFigures): ItcChartGroup =

--- a/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
@@ -135,7 +135,9 @@ class WiringSuite extends ClientSuite {
               )
             )
           )
-        )
+        ),
+        SignalToNoise.unsafeFromBigDecimalExact(1000.0),
+        SignalToNoise.fromInt(1001)
       ).asRight
     )
   }
@@ -187,6 +189,7 @@ object WiringSuite {
   val GraphInput: OptimizedSpectroscopyGraphInput =
     OptimizedSpectroscopyGraphInput(
       Wavelength.Min,
+      Wavelength.fromIntMicrometers(1),
       TimeSpan.fromSeconds(1).get,
       PosInt.unsafeFrom(5),
       SourceProfile.Point(BandNormalized[Integrated](Galaxy(Spiral).some, SortedMap.empty)),

--- a/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
@@ -41,11 +41,12 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
       .pure[IO]
 
   override def calculateGraph(
-    targetProfile: TargetProfile,
-    observingMode: ObservingMode,
-    constraints:   ItcObservingConditions,
-    exposureTime:  NonNegDuration,
-    exposures:     PosLong
+    targetProfile:   TargetProfile,
+    observingMode:   ObservingMode,
+    constraints:     ItcObservingConditions,
+    exposureTime:    NonNegDuration,
+    exposures:       PosLong,
+    signalToNoiseAt: Option[Wavelength]
   ): IO[GraphResult] =
     GraphResult(
       NonEmptyList.of(
@@ -72,7 +73,9 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
             )
           )
         )
-      )
+      ),
+      SignalToNoise.unsafeFromBigDecimalExact(1000.0),
+      SignalToNoise.fromInt(1001)
     )
       .pure[IO]
 
@@ -88,11 +91,12 @@ object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     IO.raiseError(CalculationError("A calculation error"))
 
   override def calculateGraph(
-    targetProfile: TargetProfile,
-    observingMode: ObservingMode,
-    constraints:   ItcObservingConditions,
-    exposureTime:  NonNegDuration,
-    exposures:     PosLong
+    targetProfile:   TargetProfile,
+    observingMode:   ObservingMode,
+    constraints:     ItcObservingConditions,
+    exposureTime:    NonNegDuration,
+    exposures:       PosLong,
+    signalToNoiseAt: Option[Wavelength]
   ): IO[GraphResult] =
     GraphResult(
       NonEmptyList.of(
@@ -119,6 +123,8 @@ object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
             )
           )
         )
-      )
+      ),
+      SignalToNoise.unsafeFromBigDecimalExact(1000.0),
+      SignalToNoise.fromInt(1001)
     )
       .pure[IO]


### PR DESCRIPTION
We've calculated some signal to noise values on the front end but it makes sense to move those calculations to the backend.
This only affects the graph endpoint