### PR TITLE
Internalize codec for gmos ccd

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,7 @@ val http4sVersion               = "0.23.23"
 val http4sJdkHttpClientVersion  = "0.9.1"
 val fs2Version                  = "3.8.0"
 val kindProjectorVersion        = "0.13.2"
-val lucumaCoreVersion           = "0.83.0"
-val lucumaODBSchema             = "0.5.1"
+val lucumaCoreVersion           = "0.84.0"
 val lucumaRefinedVersion        = "0.1.2"
 val slf4jVersion                = "2.0.7"
 val log4catsVersion             = "2.6.0"
@@ -156,7 +155,6 @@ lazy val client = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies ++= Seq(
       "edu.gemini"    %%% "lucuma-core"         % lucumaCoreVersion,
       "edu.gemini"    %%% "lucuma-refined"      % lucumaRefinedVersion,
-      "edu.gemini"    %%% "lucuma-odb-schema"   % lucumaODBSchema,
       "org.typelevel" %%% "cats-core"           % catsVersion,
       "org.typelevel" %%% "cats-effect"         % catsEffectVersion,
       "org.http4s"    %%% "http4s-circe"        % http4sVersion,

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/gmoscodec.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/gmoscodec.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.syntax.*
+import lucuma.core.enums.GmosAmpCount
+import lucuma.core.enums.GmosAmpGain
+import lucuma.core.enums.GmosAmpReadMode
+import lucuma.core.enums.GmosXBinning
+import lucuma.core.enums.GmosYBinning
+import lucuma.core.model.sequence.gmos.GmosCcdMode
+
+// Internalized from lucuma-odb
+trait GmosCodec {
+
+  given Decoder[GmosCcdMode] =
+    Decoder.instance { c =>
+      for {
+        x <- c.downField("xBin").as[GmosXBinning]
+        y <- c.downField("yBin").as[GmosYBinning]
+        n <- c.downField("ampCount").as[GmosAmpCount]
+        g <- c.downField("ampGain").as[GmosAmpGain]
+        m <- c.downField("ampReadMode").as[GmosAmpReadMode]
+      } yield GmosCcdMode(x, y, n, g, m)
+    }
+
+  given Encoder[GmosCcdMode] =
+    Encoder.instance { (a: GmosCcdMode) =>
+      Json.obj(
+        "xBin"        -> a.xBin.asJson,
+        "yBin"        -> a.yBin.asJson,
+        "ampCount"    -> a.ampCount.asJson,
+        "ampGain"     -> a.ampGain.asJson,
+        "ampReadMode" -> a.ampReadMode.asJson
+      )
+    }
+
+}
+
+object gmos extends GmosCodec


### PR DESCRIPTION
The dependency on `lucuma-odb-schema` cause some troubles downstream. We only need a couple of decoder/encoder thus wee can simply internalize that code