### PR TITLE
Better error reporting adding extensions to error results

### DIFF
--- a/modules/service/src/main/scala/lucuma/itc/legacy/FLocalItc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/FLocalItc.scala
@@ -6,6 +6,7 @@ package lucuma.itc.legacy
 import cats.effect.Async
 import cats.effect.kernel.syntax.all.*
 import cats.syntax.all.*
+import lucuma.itc.SourceTooBright
 import lucuma.itc.UpstreamException
 import lucuma.itc.legacy
 
@@ -15,14 +16,28 @@ import lucuma.itc.legacy
 case class FLocalItc[F[_]: Async](itcLocal: LocalItc):
   private val F = Async[F]
 
+  val TooBright =
+    """This target is too bright for this configuration."""
+  val HalfWell  = """The detector well is half filled in (\d*\.?\d*) seconds.""".r
+
   def calculateCharts(jsonParams: String): F[GraphsRemoteResult] =
     (F.cede *> F.delay(itcLocal.calculateCharts(jsonParams)).guarantee(F.cede)).flatMap {
       case Right(result) => F.pure(result)
-      case Left(msg)     => F.raiseError(new UpstreamException(msg))
+      case Left(msg)     =>
+        msg match {
+          case TooBright :: HalfWell(v) :: Nil => F.raiseError(SourceTooBright(BigDecimal(v)))
+          case _                               => F.raiseError(new UpstreamException(msg))
+        }
     }
 
   def calculateExposureTime(jsonParams: String): F[ExposureTimeRemoteResult] =
     (F.cede *> F.delay(itcLocal.calculateExposureTime(jsonParams)).guarantee(F.cede)).flatMap {
       case Right(result) => F.pure(result)
-      case Left(msg)     => F.raiseError(new UpstreamException(msg))
+      case Left(msg)     =>
+        msg match {
+          case TooBright :: HalfWell(v) :: Nil =>
+            F.raiseError(SourceTooBright(BigDecimal(v)))
+          case _                               =>
+            F.raiseError(new UpstreamException(msg))
+        }
     }

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcMappings.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcMappings.scala
@@ -14,6 +14,7 @@ import edu.gemini.grackle.circe.CirceMapping
 import eu.timepit.refined.*
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.numeric.PosInt
+import io.circe.syntax.*
 import lucuma.core.data.Zipper
 import lucuma.core.enums.*
 import lucuma.core.math.SignalToNoise
@@ -125,6 +126,10 @@ object ItcMapping extends ItcCacheOrRemote with Version {
   }
 
   private def recoverResult[A]: PartialFunction[Throwable, Result[A]] = {
+    case x @ SourceTooBright(hw) =>
+      Result.failure(
+        Problem(x.message, extension = SourceTooBrightExtension(hw).asJsonObject.some)
+      )
     case x: IntegrationTimeError =>
       Result.failure(x.message)
     case UpstreamException(msg)  =>


### PR DESCRIPTION
This produces an error like:

```json
{
  "errors": [
    {
      "message": "Source too bright, well half filled in 0.98 seconds",
      "extension": {
        "errorCode": "SOURCE_TOO_BRIGHT",
        "error": {
          "halfWell": 0.98
        }
      }
    }
  ],
  "data": null
}
```