### PR TITLE
Fix assertion error and avoids some extra calculations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,9 +102,12 @@ lazy val service = project
   .dependsOn(model.jvm)
   .settings(commonSettings)
   .settings(
-    name              := "lucuma-itc-service",
+    name                  := "lucuma-itc-service",
     scalacOptions -= "-Vtype-diffs",
-    reStart / envVars := Map(
+    reStart / javaOptions := Seq("-Dcats.effect.stackTracing=DISABLED",
+                                 "-Dcats.effect.tracing.mode=none"
+    ),
+    reStart / envVars     := Map(
       "ITC_URL"        -> "https://itc-server-exp.herokuapp.com/",
       "REDISCLOUD_URL" -> "redis://localhost"
     ),
@@ -133,7 +136,7 @@ lazy val service = project
       "io.suzaku"      %% "boopickle"             % boopickleVersion,
       "org.typelevel"  %% "munit-cats-effect"     % munitCatsEffectVersion % Test
     ),
-    buildInfoKeys     := Seq[BuildInfoKey](
+    buildInfoKeys         := Seq[BuildInfoKey](
       scalaVersion,
       sbtVersion,
       git.gitHeadCommit,

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -48,7 +48,6 @@ trait ItcCacheOrRemote extends Version:
     val hash        = Hash[A].hash(a)
     val redisKeyStr = s"$prefix:$hash"
     val redisKey    = redisKeyStr.getBytes(KeyCharset)
-    val redisKey2   = s"$redisKeyStr 1".getBytes(KeyCharset)
     val L           = Logger[F]
 
     Trace[F].span("redis-cache-read") {
@@ -56,7 +55,7 @@ trait ItcCacheOrRemote extends Version:
         _         <- Trace[F].put("redis.key" -> redisKeyStr)
         _         <- L.debug(s"Read key $redisKeyStr")
         fromRedis <- redis
-                       .get(redisKey2)
+                       .get(redisKey)
                        .handleErrorWith(e => L.error(e)(s"Error reading $redisKey") *> none.pure[F])
         decoded   <-
           fromRedis


### PR DESCRIPTION
In some edge cases (in particular with skewed central wavelength) ITC can return negative wavelengths. In that case those values are discarded.
Otherwise we may end up ignoring the CCD that has no signal leading to an assertion error