### PR TITLE
Remove unused code and rearrange parameters to better reflect meaning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / scalaVersion        := "3.5.2"
 ThisBuild / crossScalaVersions  := Seq("3.5.2")
-ThisBuild / tlBaseVersion       := "0.22"
+ThisBuild / tlBaseVersion       := "0.23"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 ThisBuild / scalacOptions ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32
 

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/ImagingIntegrationTimeInput.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/ImagingIntegrationTimeInput.scala
@@ -17,7 +17,7 @@ import lucuma.itc.client.json.syntax.*
 import lucuma.itc.encoders.given
 
 case class ImagingIntegrationTimeParameters(
-  wavelength:    Wavelength,
+  atWavelength:  Wavelength,
   signalToNoise: SignalToNoise,
   constraints:   ConstraintSet,
   mode:          InstrumentMode
@@ -28,7 +28,7 @@ object ImagingIntegrationTimeParameters {
     def apply(a: ImagingIntegrationTimeParameters): Json =
       Json
         .obj(
-          "wavelength"    -> Json.obj("picometers" -> a.wavelength.toPicometers.value.asJson),
+          "atWavelength"  -> Json.obj("picometers" -> a.atWavelength.toPicometers.value.asJson),
           "signalToNoise" -> a.signalToNoise.asJson,
           "constraints"   -> a.constraints.asJson,
           "mode"          -> a.mode.asJson

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
@@ -18,9 +18,11 @@ import lucuma.core.enums.GmosNorthGrating
 import lucuma.core.enums.GmosRoi
 import lucuma.core.enums.GmosSouthFilter
 import lucuma.core.enums.GmosSouthGrating
+import lucuma.core.math.Wavelength
 import lucuma.core.model.sequence.gmos.GmosCcdMode
 import lucuma.itc.client.json.syntax.*
 import lucuma.odb.json.gmos.given
+import lucuma.odb.json.wavelength.transport.given
 import monocle.Prism
 import monocle.macros.GenPrism
 
@@ -29,11 +31,12 @@ sealed trait InstrumentMode
 object InstrumentMode {
 
   final case class GmosNorthSpectroscopy(
-    grating: GmosNorthGrating,
-    filter:  Option[GmosNorthFilter],
-    fpu:     GmosFpu.North,
-    ccdMode: Option[GmosCcdMode],
-    roi:     Option[GmosRoi]
+    centralWavelength: Wavelength,
+    grating:           GmosNorthGrating,
+    filter:            Option[GmosNorthFilter],
+    fpu:               GmosFpu.North,
+    ccdMode:           Option[GmosCcdMode],
+    roi:               Option[GmosRoi]
   ) extends InstrumentMode
 
   object GmosNorthSpectroscopy {
@@ -42,22 +45,24 @@ object InstrumentMode {
       def apply(a: GmosNorthSpectroscopy): Json =
         Json.fromFields(
           List(
-            "grating" -> a.grating.asScreamingJson,
-            "fpu"     -> a.fpu.asJson,
-            "ccdMode" -> a.ccdMode.asJson,
-            "roi"     -> a.roi.asJson
+            "centralWavelength" -> a.centralWavelength.asJson,
+            "grating"           -> a.grating.asScreamingJson,
+            "fpu"               -> a.fpu.asJson,
+            "ccdMode"           -> a.ccdMode.asJson,
+            "roi"               -> a.roi.asJson
           ) ++ a.filter.map(_.asScreamingJson).tupleLeft("filter").toList
         )
 
     given Decoder[GmosNorthSpectroscopy] with
       def apply(c: HCursor): Decoder.Result[GmosNorthSpectroscopy] =
-        for {
-          g <- c.downField("grating").as[GmosNorthGrating]
-          f <- c.downField("filter").as[Option[GmosNorthFilter]]
-          u <- c.downField("fpu").as[GmosFpu.North]
-          d <- c.downField("ccdMode").as[Option[GmosCcdMode]]
-          r <- c.downField("roi").as[Option[GmosRoi]]
-        } yield GmosNorthSpectroscopy(g, f, u, d, r)
+        for
+          cw <- c.downField("centralWavelength").as[Wavelength]
+          g  <- c.downField("grating").as[GmosNorthGrating]
+          f  <- c.downField("filter").as[Option[GmosNorthFilter]]
+          u  <- c.downField("fpu").as[GmosFpu.North]
+          d  <- c.downField("ccdMode").as[Option[GmosCcdMode]]
+          r  <- c.downField("roi").as[Option[GmosRoi]]
+        yield GmosNorthSpectroscopy(cw, g, f, u, d, r)
 
     given Eq[GmosNorthSpectroscopy] with
       def eqv(x: GmosNorthSpectroscopy, y: GmosNorthSpectroscopy): Boolean =
@@ -68,11 +73,12 @@ object InstrumentMode {
   }
 
   final case class GmosSouthSpectroscopy(
-    grating: GmosSouthGrating,
-    filter:  Option[GmosSouthFilter],
-    fpu:     GmosFpu.South,
-    ccdMode: Option[GmosCcdMode],
-    roi:     Option[GmosRoi]
+    centralWavelength: Wavelength,
+    grating:           GmosSouthGrating,
+    filter:            Option[GmosSouthFilter],
+    fpu:               GmosFpu.South,
+    ccdMode:           Option[GmosCcdMode],
+    roi:               Option[GmosRoi]
   ) extends InstrumentMode
 
   object GmosSouthSpectroscopy {
@@ -81,22 +87,24 @@ object InstrumentMode {
       def apply(a: GmosSouthSpectroscopy): Json =
         Json.fromFields(
           List(
-            "grating" -> a.grating.asScreamingJson,
-            "fpu"     -> a.fpu.asJson,
-            "ccdMode" -> a.ccdMode.asJson,
-            "roi"     -> a.roi.asJson
+            "centralWavelength" -> a.centralWavelength.asJson,
+            "grating"           -> a.grating.asScreamingJson,
+            "fpu"               -> a.fpu.asJson,
+            "ccdMode"           -> a.ccdMode.asJson,
+            "roi"               -> a.roi.asJson
           ) ++ a.filter.map(_.asScreamingJson).tupleLeft("filter").toList
         )
 
     given Decoder[GmosSouthSpectroscopy] with
       def apply(c: HCursor): Decoder.Result[GmosSouthSpectroscopy] =
-        for {
-          g <- c.downField("grating").as[GmosSouthGrating]
-          f <- c.downField("filter").as[Option[GmosSouthFilter]]
-          u <- c.downField("fpu").as[GmosFpu.South]
-          d <- c.downField("ccdMode").as[Option[GmosCcdMode]]
-          r <- c.downField("roi").as[Option[GmosRoi]]
-        } yield GmosSouthSpectroscopy(g, f, u, d, r)
+        for
+          cw <- c.downField("centralWavelength").as[Wavelength]
+          g  <- c.downField("grating").as[GmosSouthGrating]
+          f  <- c.downField("filter").as[Option[GmosSouthFilter]]
+          u  <- c.downField("fpu").as[GmosFpu.South]
+          d  <- c.downField("ccdMode").as[Option[GmosCcdMode]]
+          r  <- c.downField("roi").as[Option[GmosRoi]]
+        yield GmosSouthSpectroscopy(cw, g, f, u, d, r)
 
     given Eq[GmosSouthSpectroscopy] with
       def eqv(x: GmosSouthSpectroscopy, y: GmosSouthSpectroscopy): Boolean =
@@ -109,41 +117,42 @@ object InstrumentMode {
   given Encoder[InstrumentMode] with
     def apply(a: InstrumentMode): Json =
       a match {
-        case a @ GmosNorthSpectroscopy(_, _, _, _, _) => Json.obj("gmosNSpectroscopy" -> a.asJson)
-        case a @ GmosSouthSpectroscopy(_, _, _, _, _) => Json.obj("gmosSSpectroscopy" -> a.asJson)
-        case a @ GmosNorthImaging(_)                  => Json.obj("gmosNImaging" -> a.asJson)
-        case a @ GmosSouthImaging(_)                  => Json.obj("gmosSImaging" -> a.asJson)
+        case a @ GmosNorthSpectroscopy(_, _, _, _, _, _) =>
+          Json.obj("gmosNSpectroscopy" -> a.asJson)
+        case a @ GmosSouthSpectroscopy(_, _, _, _, _, _) =>
+          Json.obj("gmosSSpectroscopy" -> a.asJson)
+        case a @ GmosNorthImaging(_, _)                  => Json.obj("gmosNImaging" -> a.asJson)
+        case a @ GmosSouthImaging(_, _)                  => Json.obj("gmosSImaging" -> a.asJson)
       }
 
   given Decoder[InstrumentMode] with
     def apply(c: HCursor): Decoder.Result[InstrumentMode] =
-      for {
+      for
         ns <- c.downField("gmosNSpectroscopy").as[Option[GmosNorthSpectroscopy]]
         ss <- c.downField("gmosSSpectroscopy").as[Option[GmosSouthSpectroscopy]]
         ni <- c.downField("gmosNImaging").as[Option[GmosNorthImaging]]
         si <- c.downField("gmosSImaging").as[Option[GmosSouthImaging]]
-        m  <- (ns, ss, ni, si) match {
+        m  <- (ns, ss, ni, si) match
                 case (Some(n), None, None, None) => (n: InstrumentMode).asRight
                 case (None, Some(s), None, None) => (s: InstrumentMode).asRight
                 case (None, None, Some(s), None) => (s: InstrumentMode).asRight
                 case (None, None, None, Some(s)) => (s: InstrumentMode).asRight
                 case _                           =>
                   DecodingFailure("Expected exactly one of 'gmosN' or 'gmosS'.", c.history).asLeft
-              }
-      } yield m
+      yield m
 
   given Eq[InstrumentMode] with
     def eqv(x: InstrumentMode, y: InstrumentMode): Boolean =
-      (x, y) match {
+      (x, y) match
         case (x0: GmosNorthSpectroscopy, y0: GmosNorthSpectroscopy) => x0 === y0
         case (x0: GmosSouthSpectroscopy, y0: GmosSouthSpectroscopy) => x0 === y0
         case (x0: GmosNorthImaging, y0: GmosNorthImaging)           => x0 === y0
         case (x0: GmosSouthImaging, y0: GmosSouthImaging)           => x0 === y0
         case _                                                      => false
-      }
 
   final case class GmosNorthImaging(
-    filter: GmosNorthFilter
+    filter:  GmosNorthFilter,
+    ccdMode: Option[GmosCcdMode]
   ) extends InstrumentMode
 
   object GmosNorthImaging {
@@ -151,14 +160,16 @@ object InstrumentMode {
     given Encoder[GmosNorthImaging] with
       def apply(a: GmosNorthImaging): Json =
         Json.obj(
-          "filter" -> a.filter.asScreamingJson
+          "filter"  -> a.filter.asScreamingJson,
+          "ccdMode" -> a.ccdMode.asJson
         )
 
     given Decoder[GmosNorthImaging] with
       def apply(c: HCursor): Decoder.Result[GmosNorthImaging] =
-        for {
+        for
           f <- c.downField("filter").as[GmosNorthFilter]
-        } yield GmosNorthImaging(f)
+          c <- c.downField("ccdMode").as[Option[GmosCcdMode]]
+        yield GmosNorthImaging(f, c)
 
     given Eq[GmosNorthImaging] with
       def eqv(x: GmosNorthImaging, y: GmosNorthImaging): Boolean =
@@ -167,7 +178,8 @@ object InstrumentMode {
   }
 
   final case class GmosSouthImaging(
-    filter: GmosSouthFilter
+    filter:  GmosSouthFilter,
+    ccdMode: Option[GmosCcdMode]
   ) extends InstrumentMode
 
   object GmosSouthImaging {
@@ -175,14 +187,16 @@ object InstrumentMode {
     given Encoder[GmosSouthImaging] with
       def apply(a: GmosSouthImaging): Json =
         Json.obj(
-          "filter" -> a.filter.asScreamingJson
+          "filter"  -> a.filter.asScreamingJson,
+          "ccdMode" -> a.ccdMode.asJson
         )
 
     given Decoder[GmosSouthImaging] with
       def apply(c: HCursor): Decoder.Result[GmosSouthImaging] =
-        for {
+        for
           f <- c.downField("filter").as[GmosSouthFilter]
-        } yield GmosSouthImaging(f)
+          c <- c.downField("ccdMode").as[Option[GmosCcdMode]]
+        yield GmosSouthImaging(f, c)
 
     given Eq[GmosSouthImaging] with
       def eqv(x: GmosSouthImaging, y: GmosSouthImaging): Boolean =

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.syntax.either.*
 import cats.syntax.eq.*
 import cats.syntax.functor.*
+import cats.derived.*
 import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.Encoder
@@ -30,7 +31,7 @@ sealed trait InstrumentMode
 
 object InstrumentMode {
 
-  final case class GmosNorthSpectroscopy(
+  case class GmosNorthSpectroscopy(
     centralWavelength: Wavelength,
     grating:           GmosNorthGrating,
     filter:            Option[GmosNorthFilter],
@@ -38,6 +39,7 @@ object InstrumentMode {
     ccdMode:           Option[GmosCcdMode],
     roi:               Option[GmosRoi]
   ) extends InstrumentMode
+      derives Eq
 
   object GmosNorthSpectroscopy {
 
@@ -64,15 +66,9 @@ object InstrumentMode {
           r  <- c.downField("roi").as[Option[GmosRoi]]
         yield GmosNorthSpectroscopy(cw, g, f, u, d, r)
 
-    given Eq[GmosNorthSpectroscopy] with
-      def eqv(x: GmosNorthSpectroscopy, y: GmosNorthSpectroscopy): Boolean =
-        (x.grating === y.grating) &&
-          (x.filter === y.filter) &&
-          (x.fpu === y.fpu)
-
   }
 
-  final case class GmosSouthSpectroscopy(
+  case class GmosSouthSpectroscopy(
     centralWavelength: Wavelength,
     grating:           GmosSouthGrating,
     filter:            Option[GmosSouthFilter],
@@ -80,6 +76,7 @@ object InstrumentMode {
     ccdMode:           Option[GmosCcdMode],
     roi:               Option[GmosRoi]
   ) extends InstrumentMode
+      derives Eq
 
   object GmosSouthSpectroscopy {
 
@@ -105,13 +102,6 @@ object InstrumentMode {
           d  <- c.downField("ccdMode").as[Option[GmosCcdMode]]
           r  <- c.downField("roi").as[Option[GmosRoi]]
         yield GmosSouthSpectroscopy(cw, g, f, u, d, r)
-
-    given Eq[GmosSouthSpectroscopy] with
-      def eqv(x: GmosSouthSpectroscopy, y: GmosSouthSpectroscopy): Boolean =
-        (x.grating === y.grating) &&
-          (x.filter === y.filter) &&
-          (x.fpu === y.fpu)
-
   }
 
   given Encoder[InstrumentMode] with
@@ -121,8 +111,10 @@ object InstrumentMode {
           Json.obj("gmosNSpectroscopy" -> a.asJson)
         case a @ GmosSouthSpectroscopy(_, _, _, _, _, _) =>
           Json.obj("gmosSSpectroscopy" -> a.asJson)
-        case a @ GmosNorthImaging(_, _)                  => Json.obj("gmosNImaging" -> a.asJson)
-        case a @ GmosSouthImaging(_, _)                  => Json.obj("gmosSImaging" -> a.asJson)
+        case a @ GmosNorthImaging(_, _)                  =>
+          Json.obj("gmosNImaging" -> a.asJson)
+        case a @ GmosSouthImaging(_, _)                  =>
+          Json.obj("gmosSImaging" -> a.asJson)
       }
 
   given Decoder[InstrumentMode] with
@@ -150,10 +142,11 @@ object InstrumentMode {
         case (x0: GmosSouthImaging, y0: GmosSouthImaging)           => x0 === y0
         case _                                                      => false
 
-  final case class GmosNorthImaging(
+  case class GmosNorthImaging(
     filter:  GmosNorthFilter,
     ccdMode: Option[GmosCcdMode]
   ) extends InstrumentMode
+      derives Eq
 
   object GmosNorthImaging {
 
@@ -170,17 +163,13 @@ object InstrumentMode {
           f <- c.downField("filter").as[GmosNorthFilter]
           c <- c.downField("ccdMode").as[Option[GmosCcdMode]]
         yield GmosNorthImaging(f, c)
-
-    given Eq[GmosNorthImaging] with
-      def eqv(x: GmosNorthImaging, y: GmosNorthImaging): Boolean =
-        x.filter === y.filter
-
   }
 
-  final case class GmosSouthImaging(
+  case class GmosSouthImaging(
     filter:  GmosSouthFilter,
     ccdMode: Option[GmosCcdMode]
   ) extends InstrumentMode
+      derives Eq
 
   object GmosSouthImaging {
 
@@ -197,11 +186,6 @@ object InstrumentMode {
           f <- c.downField("filter").as[GmosSouthFilter]
           c <- c.downField("ccdMode").as[Option[GmosCcdMode]]
         yield GmosSouthImaging(f, c)
-
-    given Eq[GmosSouthImaging] with
-      def eqv(x: GmosSouthImaging, y: GmosSouthImaging): Boolean =
-        x.filter === y.filter
-
   }
 
   val gmosNorthSpectroscopy: Prism[InstrumentMode, GmosNorthSpectroscopy] =

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
@@ -38,8 +38,7 @@ object InstrumentMode {
     fpu:               GmosFpu.North,
     ccdMode:           Option[GmosCcdMode],
     roi:               Option[GmosRoi]
-  ) extends InstrumentMode
-      derives Eq
+  ) extends InstrumentMode derives Eq
 
   object GmosNorthSpectroscopy {
 
@@ -75,8 +74,7 @@ object InstrumentMode {
     fpu:               GmosFpu.South,
     ccdMode:           Option[GmosCcdMode],
     roi:               Option[GmosRoi]
-  ) extends InstrumentMode
-      derives Eq
+  ) extends InstrumentMode derives Eq
 
   object GmosSouthSpectroscopy {
 
@@ -145,8 +143,7 @@ object InstrumentMode {
   case class GmosNorthImaging(
     filter:  GmosNorthFilter,
     ccdMode: Option[GmosCcdMode]
-  ) extends InstrumentMode
-      derives Eq
+  ) extends InstrumentMode derives Eq
 
   object GmosNorthImaging {
 
@@ -168,8 +165,7 @@ object InstrumentMode {
   case class GmosSouthImaging(
     filter:  GmosSouthFilter,
     ccdMode: Option[GmosCcdMode]
-  ) extends InstrumentMode
-      derives Eq
+  ) extends InstrumentMode derives Eq
 
   object GmosSouthImaging {
 

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
@@ -4,10 +4,10 @@
 package lucuma.itc.client
 
 import cats.Eq
+import cats.derived.*
 import cats.syntax.either.*
 import cats.syntax.eq.*
 import cats.syntax.functor.*
-import cats.derived.*
 import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.Encoder

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyGraphsInput.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyGraphsInput.scala
@@ -20,7 +20,7 @@ import lucuma.itc.client.json.syntax.*
 import lucuma.itc.encoders.given
 
 case class SpectroscopyGraphParameters(
-  wavelength:         Wavelength,
+  atWavelength:       Wavelength,
   exposureTime:       TimeSpan,
   exposureCount:      PosInt,
   constraints:        ConstraintSet,
@@ -39,7 +39,7 @@ object SpectroscopyGraphsInput {
 
   given Encoder.AsObject[SpectroscopyGraphsInput] = a =>
     JsonObject(
-      "wavelength"         -> Json.obj("picometers" -> a.wavelength.toPicometers.value.asJson),
+      "atWavelength"       -> Json.obj("picometers" -> a.atWavelength.toPicometers.value.asJson),
       "exposureTime"       -> Json.obj("microseconds" -> a.exposureTime.asJson),
       "exposureCount"      -> a.exposureCount.value.asJson,
       "asterism"           -> a.asterism.asJson,

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyGraphsInput.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyGraphsInput.scala
@@ -21,7 +21,6 @@ import lucuma.itc.encoders.given
 
 case class SpectroscopyGraphParameters(
   wavelength:         Wavelength,
-  signalToNoiseAt:    Option[Wavelength],
   exposureTime:       TimeSpan,
   exposureCount:      PosInt,
   constraints:        ConstraintSet,
@@ -41,9 +40,6 @@ object SpectroscopyGraphsInput {
   given Encoder.AsObject[SpectroscopyGraphsInput] = a =>
     JsonObject(
       "wavelength"         -> Json.obj("picometers" -> a.wavelength.toPicometers.value.asJson),
-      "signalToNoiseAt"    -> a.signalToNoiseAt
-        .map(w => Json.obj("picometers" -> w.toPicometers.value.asJson))
-        .asJson,
       "exposureTime"       -> Json.obj("microseconds" -> a.exposureTime.asJson),
       "exposureCount"      -> a.exposureCount.value.asJson,
       "asterism"           -> a.asterism.asJson,

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyIntegrationTimeInput.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyIntegrationTimeInput.scala
@@ -17,11 +17,10 @@ import lucuma.itc.client.json.syntax.*
 import lucuma.itc.encoders.given
 
 case class SpectroscopyIntegrationTimeParameters(
-  wavelength:      Wavelength,
-  signalToNoise:   SignalToNoise,
-  signalToNoiseAt: Option[Wavelength],
-  constraints:     ConstraintSet,
-  mode:            InstrumentMode
+  wavelength:    Wavelength,
+  signalToNoise: SignalToNoise,
+  constraints:   ConstraintSet,
+  mode:          InstrumentMode
 ) derives Eq
 
 object SpectroscopyIntegrationTimeParameters {
@@ -29,13 +28,10 @@ object SpectroscopyIntegrationTimeParameters {
     def apply(a: SpectroscopyIntegrationTimeParameters): Json =
       Json
         .obj(
-          "wavelength"      -> Json.obj("picometers" -> a.wavelength.toPicometers.value.asJson),
-          "signalToNoise"   -> a.signalToNoise.asJson,
-          "signalToNoiseAt" -> a.signalToNoiseAt
-            .map(w => Json.obj("picometers" -> w.toPicometers.value.asJson))
-            .asJson,
-          "constraints"     -> a.constraints.asJson,
-          "mode"            -> a.mode.asJson
+          "wavelength"    -> Json.obj("picometers" -> a.wavelength.toPicometers.value.asJson),
+          "signalToNoise" -> a.signalToNoise.asJson,
+          "constraints"   -> a.constraints.asJson,
+          "mode"          -> a.mode.asJson
         )
         .dropNullValues
 }

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyIntegrationTimeInput.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyIntegrationTimeInput.scala
@@ -17,7 +17,7 @@ import lucuma.itc.client.json.syntax.*
 import lucuma.itc.encoders.given
 
 case class SpectroscopyIntegrationTimeParameters(
-  wavelength:    Wavelength,
+  atWavelength:  Wavelength,
   signalToNoise: SignalToNoise,
   constraints:   ConstraintSet,
   mode:          InstrumentMode
@@ -28,7 +28,7 @@ object SpectroscopyIntegrationTimeParameters {
     def apply(a: SpectroscopyIntegrationTimeParameters): Json =
       Json
         .obj(
-          "wavelength"    -> Json.obj("picometers" -> a.wavelength.toPicometers.value.asJson),
+          "atWavelength"  -> Json.obj("picometers" -> a.atWavelength.toPicometers.value.asJson),
           "signalToNoise" -> a.signalToNoise.asJson,
           "constraints"   -> a.constraints.asJson,
           "mode"          -> a.mode.asJson

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyTimeAndGraphInput.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyTimeAndGraphInput.scala
@@ -20,7 +20,7 @@ import lucuma.itc.client.json.syntax.*
 import lucuma.itc.encoders.given
 
 case class SpectroscopyIntegrationTimeAndGraphsParameters(
-  wavelength:         Wavelength,
+  atWavelength:       Wavelength,
   signalToNoise:      SignalToNoise,
   constraints:        ConstraintSet,
   mode:               InstrumentMode,
@@ -30,7 +30,7 @@ case class SpectroscopyIntegrationTimeAndGraphsParameters(
 object SpectroscopyIntegrationTimeAndGraphsParameters {
   given Encoder.AsObject[SpectroscopyIntegrationTimeAndGraphsParameters] = a =>
     JsonObject(
-      "wavelength"         -> Json.obj("picometers" -> a.wavelength.toPicometers.value.asJson),
+      "atWavelength"       -> Json.obj("picometers" -> a.atWavelength.toPicometers.value.asJson),
       "signalToNoise"      -> a.signalToNoise.asJson,
       "constraints"        -> a.constraints.asJson,
       "mode"               -> a.mode.asJson,

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyTimeAndGraphInput.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyTimeAndGraphInput.scala
@@ -22,7 +22,6 @@ import lucuma.itc.encoders.given
 case class SpectroscopyIntegrationTimeAndGraphsParameters(
   wavelength:         Wavelength,
   signalToNoise:      SignalToNoise,
-  signalToNoiseAt:    Option[Wavelength],
   constraints:        ConstraintSet,
   mode:               InstrumentMode,
   significantFigures: Option[SignificantFiguresInput]
@@ -33,9 +32,6 @@ object SpectroscopyIntegrationTimeAndGraphsParameters {
     JsonObject(
       "wavelength"         -> Json.obj("picometers" -> a.wavelength.toPicometers.value.asJson),
       "signalToNoise"      -> a.signalToNoise.asJson,
-      "signalToNoiseAt"    -> a.signalToNoiseAt
-        .map(w => Json.obj("picometers" -> w.toPicometers.value.asJson))
-        .asJson,
       "constraints"        -> a.constraints.asJson,
       "mode"               -> a.mode.asJson,
       "significantFigures" -> a.significantFigures.asJson

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/json/wavelength.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/json/wavelength.scala
@@ -27,24 +27,39 @@ object wavelength {
       Decoder.instance { c =>
         def fromDecimal(field: String, fmt: Format[BigDecimal, A]): Decoder.Result[A] =
           c.downField(field).as[BigDecimal].flatMap { bd =>
-            fmt.getOption(bd).toRight(DecodingFailure(s"Invalid $field $name value: $bd", c.history))
+            fmt
+              .getOption(bd)
+              .toRight(DecodingFailure(s"Invalid $field $name value: $bd", c.history))
           }
 
-        c.downField("picometers").as[Int].flatMap { pm =>
-          pmPrism
-            .getOption(pm)
-            .toRight(DecodingFailure(s"Invalid $name picometers value: $pm", c.history))
-        } orElse
-        fromDecimal("angstroms", aFormat) orElse
-        fromDecimal("nanometers", nmFormat) orElse
-        fromDecimal("micrometers", µmFormat)
+        c.downField("picometers")
+          .as[Int]
+          .flatMap { pm =>
+            pmPrism
+              .getOption(pm)
+              .toRight(DecodingFailure(s"Invalid $name picometers value: $pm", c.history))
+          }
+          .orElse(fromDecimal("angstroms", aFormat))
+          .orElse(fromDecimal("nanometers", nmFormat))
+          .orElse(fromDecimal("micrometers", µmFormat))
       }
 
     given Decoder[Wavelength] =
-      wavelengthDecoder("wavelength", Wavelength.intPicometers, Wavelength.decimalAngstroms, Wavelength.decimalNanometers, Wavelength.decimalMicrometers)
+      wavelengthDecoder("wavelength",
+                        Wavelength.intPicometers,
+                        Wavelength.decimalAngstroms,
+                        Wavelength.decimalNanometers,
+                        Wavelength.decimalMicrometers
+      )
 
     given Decoder[WavelengthDither] =
-      wavelengthDecoder("wavelength dither", WavelengthDither.intPicometers, WavelengthDither.decimalAngstroms, WavelengthDither.decimalNanometers, WavelengthDither.decimalMicrometers)
+      wavelengthDecoder(
+        "wavelength dither",
+        WavelengthDither.intPicometers,
+        WavelengthDither.decimalAngstroms,
+        WavelengthDither.decimalNanometers,
+        WavelengthDither.decimalMicrometers
+      )
 
   }
 
@@ -62,15 +77,23 @@ object wavelength {
           "picometers"  -> pmPrism.reverseGet(a).asJson,
           "angstroms"   -> aFormat.reverseGet(a).asJson,
           "nanometers"  -> nmFormat.reverseGet(a).asJson,
-          "micrometers" -> µmFormat.reverseGet(a).asJson,
+          "micrometers" -> µmFormat.reverseGet(a).asJson
         )
       }
 
     given Encoder_Wavelength: Encoder[Wavelength] =
-      wavelengthEncoder(Wavelength.intPicometers, Wavelength.decimalAngstroms, Wavelength.decimalNanometers, Wavelength.decimalMicrometers)
+      wavelengthEncoder(Wavelength.intPicometers,
+                        Wavelength.decimalAngstroms,
+                        Wavelength.decimalNanometers,
+                        Wavelength.decimalMicrometers
+      )
 
     given Encoder_WavelengthDither: Encoder[WavelengthDither] =
-      wavelengthEncoder(WavelengthDither.intPicometers, WavelengthDither.decimalAngstroms, WavelengthDither.decimalNanometers, WavelengthDither.decimalMicrometers)
+      wavelengthEncoder(WavelengthDither.intPicometers,
+                        WavelengthDither.decimalAngstroms,
+                        WavelengthDither.decimalNanometers,
+                        WavelengthDither.decimalMicrometers
+      )
   }
 
   object query extends QueryCodec
@@ -79,14 +102,14 @@ object wavelength {
     given Encoder_Wavelength: Encoder[Wavelength] =
       Encoder.instance { (w: Wavelength) =>
         Json.obj(
-          "picometers"  -> w.toPicometers.value.value.asJson
+          "picometers" -> w.toPicometers.value.value.asJson
         )
       }
 
     given Encoder_WavelengthDither: Encoder[WavelengthDither] =
       Encoder.instance { (w: WavelengthDither) =>
         Json.obj(
-          "picometers"  -> w.toPicometers.value.asJson
+          "picometers" -> w.toPicometers.value.asJson
         )
       }
   }
@@ -94,4 +117,3 @@ object wavelength {
   object transport extends TransportCodec
 
 }
-

--- a/modules/client/shared/src/main/scala/lucuma/itc/client/json/wavelength.scala
+++ b/modules/client/shared/src/main/scala/lucuma/itc/client/json/wavelength.scala
@@ -1,0 +1,97 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.syntax.*
+import lucuma.core.math.Wavelength
+import lucuma.core.math.WavelengthDither
+import lucuma.core.optics.Format
+import monocle.Prism
+
+object wavelength {
+
+  trait DecoderWavelength {
+
+    private def wavelengthDecoder[A](
+      name:     String,
+      pmPrism:  Prism[Int, A],
+      aFormat:  Format[BigDecimal, A],
+      nmFormat: Format[BigDecimal, A],
+      µmFormat: Format[BigDecimal, A]
+    ): Decoder[A] =
+      Decoder.instance { c =>
+        def fromDecimal(field: String, fmt: Format[BigDecimal, A]): Decoder.Result[A] =
+          c.downField(field).as[BigDecimal].flatMap { bd =>
+            fmt.getOption(bd).toRight(DecodingFailure(s"Invalid $field $name value: $bd", c.history))
+          }
+
+        c.downField("picometers").as[Int].flatMap { pm =>
+          pmPrism
+            .getOption(pm)
+            .toRight(DecodingFailure(s"Invalid $name picometers value: $pm", c.history))
+        } orElse
+        fromDecimal("angstroms", aFormat) orElse
+        fromDecimal("nanometers", nmFormat) orElse
+        fromDecimal("micrometers", µmFormat)
+      }
+
+    given Decoder[Wavelength] =
+      wavelengthDecoder("wavelength", Wavelength.intPicometers, Wavelength.decimalAngstroms, Wavelength.decimalNanometers, Wavelength.decimalMicrometers)
+
+    given Decoder[WavelengthDither] =
+      wavelengthDecoder("wavelength dither", WavelengthDither.intPicometers, WavelengthDither.decimalAngstroms, WavelengthDither.decimalNanometers, WavelengthDither.decimalMicrometers)
+
+  }
+
+  object decoder extends DecoderWavelength
+
+  trait QueryCodec extends DecoderWavelength {
+    private def wavelengthEncoder[A](
+      pmPrism:  Prism[Int, A],
+      aFormat:  Format[BigDecimal, A],
+      nmFormat: Format[BigDecimal, A],
+      µmFormat: Format[BigDecimal, A]
+    ): Encoder[A] =
+      Encoder.instance { (a: A) =>
+        Json.obj(
+          "picometers"  -> pmPrism.reverseGet(a).asJson,
+          "angstroms"   -> aFormat.reverseGet(a).asJson,
+          "nanometers"  -> nmFormat.reverseGet(a).asJson,
+          "micrometers" -> µmFormat.reverseGet(a).asJson,
+        )
+      }
+
+    given Encoder_Wavelength: Encoder[Wavelength] =
+      wavelengthEncoder(Wavelength.intPicometers, Wavelength.decimalAngstroms, Wavelength.decimalNanometers, Wavelength.decimalMicrometers)
+
+    given Encoder_WavelengthDither: Encoder[WavelengthDither] =
+      wavelengthEncoder(WavelengthDither.intPicometers, WavelengthDither.decimalAngstroms, WavelengthDither.decimalNanometers, WavelengthDither.decimalMicrometers)
+  }
+
+  object query extends QueryCodec
+
+  trait TransportCodec extends DecoderWavelength {
+    given Encoder_Wavelength: Encoder[Wavelength] =
+      Encoder.instance { (w: Wavelength) =>
+        Json.obj(
+          "picometers"  -> w.toPicometers.value.value.asJson
+        )
+      }
+
+    given Encoder_WavelengthDither: Encoder[WavelengthDither] =
+      Encoder.instance { (w: WavelengthDither) =>
+        Json.obj(
+          "picometers"  -> w.toPicometers.value.asJson
+        )
+      }
+  }
+
+  object transport extends TransportCodec
+
+}
+

--- a/modules/service/src/main/resources/graphql/itc.graphql
+++ b/modules/service/src/main/resources/graphql/itc.graphql
@@ -10267,7 +10267,7 @@ type ItcVersions {
 
 input GmosSSpectroscopyInput {
   # Center of the configuration spectrum
-  centralWavelength: Wavelength
+  centralWavelength: WavelengthInput!
 
   # Gmos South disperser
   grating: GmosSouthGrating!
@@ -10295,7 +10295,7 @@ input GmosSImagingInput {
 
 input GmosNSpectroscopyInput {
   # Center of the configuration spectrum
-  centralWavelength: Wavelength
+  centralWavelength: WavelengthInput!
 
   # Gmos North disperser
   grating: GmosNorthGrating!
@@ -10381,7 +10381,7 @@ input SpectroscopyIntegrationTimeInput {
   constraints: ConstraintSetInput!
 
   # Instrument modes
-  mode: InstrumentModesInput
+  mode: InstrumentModesInput!
 }
 
 input TargetInput {
@@ -10407,7 +10407,7 @@ input ImagingIntegrationTimeInput {
   constraints: ConstraintSetInput!
 
   # Instrument modes
-  mode: InstrumentModesInput
+  mode: InstrumentModesInput!
 }
 
 # Params for significant figures on each axis
@@ -10520,15 +10520,15 @@ type TargetError {
 
 interface ITCObservingMode {
   # instrument
-  instrument: Instrument
+  instrument: Instrument!
 }
 
 type ImagingMode implements ITCObservingMode {
   # Wavelength in appropriate units
-  centralWavelength: Wavelength!
+  # centralWavelength: Wavelength!
 
   # instrument
-  instrument: Instrument
+  instrument: Instrument!
 
   # params
   params: InstrumentITCParams!
@@ -10545,7 +10545,7 @@ type SpectroscopyMode implements ITCObservingMode {
   params: InstrumentITCParams!
 
   # instrument
-  instrument: Instrument
+  instrument: Instrument!
 }
 
 """Graph data types"""

--- a/modules/service/src/main/resources/graphql/itc.graphql
+++ b/modules/service/src/main/resources/graphql/itc.graphql
@@ -10366,7 +10366,7 @@ input InstrumentModesInput {
   gmosSImaging: GmosSImagingInput
 }
 
-# Configuration alternatives query
+# Params for spectroscopy integration time calculation
 input SpectroscopyIntegrationTimeInput {
   # Observing wavelength.
   atWavelength: WavelengthInput!
@@ -10392,7 +10392,7 @@ input TargetInput {
   radialVelocity: RadialVelocityInput!
 }
 
-# Configuration alternatives query
+# Params for imaging integration time calculation
 input ImagingIntegrationTimeInput {
   # Observing wavelength.
   atWavelength: WavelengthInput!
@@ -10422,7 +10422,7 @@ input SignificantFiguresInput {
   ccd: PosInt
 }
 
-# Parameters to retrieve graph data
+# Params for spectroscopy graphs calculation
 input SpectroscopyGraphsInput {
   # Observing wavelength.
   atWavelength: WavelengthInput!

--- a/modules/service/src/main/resources/graphql/itc.graphql
+++ b/modules/service/src/main/resources/graphql/itc.graphql
@@ -10368,9 +10368,6 @@ input SpectroscopyIntegrationTimeInput {
   # Minimum desired signal-to-noise ratio.
   signalToNoise: SignalToNoise!
 
-  # Wavelength at which to measure Signal to Noise
-  signalToNoiseAt: WavelengthInput
-
   # Relevant data for targets in asterism.
   asterism: [TargetInput!]!
 
@@ -10424,9 +10421,6 @@ input SpectroscopyGraphsInput {
   # Observing wavelength.
   wavelength: WavelengthInput!
 
-  # Wavelength at which to measure Signal to Noise
-  signalToNoiseAt: WavelengthInput
-
   # Exposure time duration
   exposureTime: TimeSpanInput!
 
@@ -10453,9 +10447,6 @@ input SpectroscopyIntegrationTimeAndGraphsInput {
 
   # Minimum desired signal-to-noise ratio.
   signalToNoise: SignalToNoise!
-
-  # Wavelength at which to measure Signal to Noise
-  signalToNoiseAt: WavelengthInput
 
   # Relevant data for targets in asterism.
   asterism: [TargetInput!]!

--- a/modules/service/src/main/resources/graphql/itc.graphql
+++ b/modules/service/src/main/resources/graphql/itc.graphql
@@ -10525,7 +10525,7 @@ interface ITCObservingMode {
 
 type ImagingMode implements ITCObservingMode {
   # Wavelength in appropriate units
-  wavelength: Wavelength!
+  centralWavelength: Wavelength!
 
   # instrument
   instrument: Instrument
@@ -10536,7 +10536,7 @@ type ImagingMode implements ITCObservingMode {
 
 type SpectroscopyMode implements ITCObservingMode {
   # Wavelength in appropriate units
-  wavelength: Wavelength!
+  centralWavelength: Wavelength!
 
   # Resolution
   resolution: BigDecimal!

--- a/modules/service/src/main/resources/graphql/itc.graphql
+++ b/modules/service/src/main/resources/graphql/itc.graphql
@@ -10524,9 +10524,6 @@ interface ITCObservingMode {
 }
 
 type ImagingMode implements ITCObservingMode {
-  # Wavelength in appropriate units
-  # centralWavelength: Wavelength!
-
   # instrument
   instrument: Instrument!
 

--- a/modules/service/src/main/resources/graphql/itc.graphql
+++ b/modules/service/src/main/resources/graphql/itc.graphql
@@ -10266,6 +10266,9 @@ type ItcVersions {
 }
 
 input GmosSSpectroscopyInput {
+  # Center of the configuration spectrum
+  centralWavelength: Wavelength
+
   # Gmos South disperser
   grating: GmosSouthGrating!
 
@@ -10291,6 +10294,9 @@ input GmosSImagingInput {
 }
 
 input GmosNSpectroscopyInput {
+  # Center of the configuration spectrum
+  centralWavelength: Wavelength
+
   # Gmos North disperser
   grating: GmosNorthGrating!
 
@@ -10363,7 +10369,7 @@ input InstrumentModesInput {
 # Configuration alternatives query
 input SpectroscopyIntegrationTimeInput {
   # Observing wavelength.
-  wavelength: WavelengthInput!
+  atWavelength: WavelengthInput!
 
   # Minimum desired signal-to-noise ratio.
   signalToNoise: SignalToNoise!
@@ -10389,7 +10395,7 @@ input TargetInput {
 # Configuration alternatives query
 input ImagingIntegrationTimeInput {
   # Observing wavelength.
-  wavelength: WavelengthInput!
+  atWavelength: WavelengthInput!
 
   # Minimum desired signal-to-noise ratio.
   signalToNoise: SignalToNoise!
@@ -10419,7 +10425,7 @@ input SignificantFiguresInput {
 # Parameters to retrieve graph data
 input SpectroscopyGraphsInput {
   # Observing wavelength.
-  wavelength: WavelengthInput!
+  atWavelength: WavelengthInput!
 
   # Exposure time duration
   exposureTime: TimeSpanInput!
@@ -10443,7 +10449,7 @@ input SpectroscopyGraphsInput {
 # Parameters to retrieve graph data
 input SpectroscopyIntegrationTimeAndGraphsInput {
   # Observing wavelength.
-  wavelength: WavelengthInput!
+  atWavelength: WavelengthInput!
 
   # Minimum desired signal-to-noise ratio.
   signalToNoise: SignalToNoise!

--- a/modules/service/src/main/scala/lucuma/itc/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/Itc.scala
@@ -7,6 +7,7 @@ import cats.data.NonEmptyChain
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.Band
 import lucuma.core.math.SignalToNoise
+import lucuma.core.math.Wavelength
 import lucuma.core.util.TimeSpan
 import lucuma.itc.search.*
 
@@ -21,7 +22,8 @@ trait Itc[F[_]]:
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
-    signalToNoise: SignalToNoise
+    signalToNoise: SignalToNoise,
+    wavelength:    Wavelength
   ): F[NonEmptyChain[IntegrationTime]]
 
   /**
@@ -33,7 +35,8 @@ trait Itc[F[_]]:
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
     exposureTime:  TimeSpan,
-    exposureCount: PosInt
+    exposureCount: PosInt,
+    wavelength:    Wavelength
   ): F[TargetGraphsCalcResult]
 
   // /**

--- a/modules/service/src/main/scala/lucuma/itc/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/Itc.scala
@@ -18,25 +18,23 @@ trait Itc[F[_]]:
    * signal-to-noise under the requested conditions.
    */
   def calculateIntegrationTime(
-    target:          TargetData,
-    band:            Band,
-    observingMode:   ObservingMode,
-    constraints:     ItcObservingConditions,
-    signalToNoise:   SignalToNoise,
-    signalToNoiseAt: Option[Wavelength]
+    target:        TargetData,
+    band:          Band,
+    observingMode: ObservingMode,
+    constraints:   ItcObservingConditions,
+    signalToNoise: SignalToNoise
   ): F[NonEmptyChain[IntegrationTime]]
 
   /**
    * Retrieve the graph data for the given mode and exposureTime and exposures
    */
   def calculateGraph(
-    target:          TargetData,
-    band:            Band,
-    observingMode:   ObservingMode,
-    constraints:     ItcObservingConditions,
-    exposureTime:    TimeSpan,
-    exposureCount:   PosInt,
-    signalToNoiseAt: Option[Wavelength]
+    target:        TargetData,
+    band:          Band,
+    observingMode: ObservingMode,
+    constraints:   ItcObservingConditions,
+    exposureTime:  TimeSpan,
+    exposureCount: PosInt
   ): F[TargetGraphsCalcResult]
 
   /**
@@ -44,10 +42,8 @@ trait Itc[F[_]]:
    * exposures at a specific wavelength
    */
   def calculateSignalToNoise(
-    graph:           NonEmptyChain[ItcGraphGroup],
-    signalToNoiseAt: Option[Wavelength]
+    graph: NonEmptyChain[ItcGraphGroup]
   ): F[SNCalcResult]
 
 object Itc:
-
   def apply[F[_]](using ev: Itc[F]): ev.type = ev

--- a/modules/service/src/main/scala/lucuma/itc/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/Itc.scala
@@ -16,7 +16,7 @@ trait Itc[F[_]]:
    * Compute the exposure time and number of exposures required to achieve the desired
    * signal-to-noise under the requested conditions.
    */
-  def calculateExposureTime(
+  def calculateIntegrationTime(
     target:        TargetData,
     band:          Band,
     observingMode: ObservingMode,

--- a/modules/service/src/main/scala/lucuma/itc/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/Itc.scala
@@ -7,7 +7,6 @@ import cats.data.NonEmptyChain
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.Band
 import lucuma.core.math.SignalToNoise
-import lucuma.core.math.Wavelength
 import lucuma.core.util.TimeSpan
 import lucuma.itc.search.*
 
@@ -22,8 +21,7 @@ trait Itc[F[_]]:
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
-    signalToNoise: SignalToNoise,
-    wavelength:    Wavelength
+    signalToNoise: SignalToNoise
   ): F[NonEmptyChain[IntegrationTime]]
 
   /**
@@ -35,8 +33,7 @@ trait Itc[F[_]]:
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
     exposureTime:  TimeSpan,
-    exposureCount: PosInt,
-    wavelength:    Wavelength
+    exposureCount: PosInt
   ): F[TargetGraphsCalcResult]
 
   // /**

--- a/modules/service/src/main/scala/lucuma/itc/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/Itc.scala
@@ -7,7 +7,6 @@ import cats.data.NonEmptyChain
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.Band
 import lucuma.core.math.SignalToNoise
-import lucuma.core.math.Wavelength
 import lucuma.core.util.TimeSpan
 import lucuma.itc.search.*
 
@@ -17,7 +16,7 @@ trait Itc[F[_]]:
    * Compute the exposure time and number of exposures required to achieve the desired
    * signal-to-noise under the requested conditions.
    */
-  def calculateIntegrationTime(
+  def calculateExposureTime(
     target:        TargetData,
     band:          Band,
     observingMode: ObservingMode,
@@ -37,13 +36,13 @@ trait Itc[F[_]]:
     exposureCount: PosInt
   ): F[TargetGraphsCalcResult]
 
-  /**
-   * Calculate the signal to noise from graph data for the given mode and exposureTime and amount of
-   * exposures at a specific wavelength
-   */
-  def calculateSignalToNoise(
-    graph: NonEmptyChain[ItcGraphGroup]
-  ): F[SNCalcResult]
+  // /**
+  //  * Calculate the signal to noise from graph data for the given mode and exposureTime and amount of
+  //  * exposures at a specific wavelength
+  //  */
+  // def calculateSignalToNoise(
+  //   graph: NonEmptyChain[ItcGraphGroup]
+  // ): F[SNCalcResult]
 
 object Itc:
   def apply[F[_]](using ev: Itc[F]): ev.type = ev

--- a/modules/service/src/main/scala/lucuma/itc/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/Itc.scala
@@ -7,6 +7,7 @@ import cats.data.NonEmptyChain
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.Band
 import lucuma.core.math.SignalToNoise
+import lucuma.core.math.Wavelength
 import lucuma.core.util.TimeSpan
 import lucuma.itc.search.*
 
@@ -18,6 +19,7 @@ trait Itc[F[_]]:
    */
   def calculateIntegrationTime(
     target:        TargetData,
+    atWavelength:  Wavelength,
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
@@ -29,6 +31,7 @@ trait Itc[F[_]]:
    */
   def calculateGraph(
     target:        TargetData,
+    atWavelength:  Wavelength,
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,

--- a/modules/service/src/main/scala/lucuma/itc/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/Itc.scala
@@ -39,13 +39,5 @@ trait Itc[F[_]]:
     exposureCount: PosInt
   ): F[TargetGraphsCalcResult]
 
-  // /**
-  //  * Calculate the signal to noise from graph data for the given mode and exposureTime and amount of
-  //  * exposures at a specific wavelength
-  //  */
-  // def calculateSignalToNoise(
-  //   graph: NonEmptyChain[ItcGraphGroup]
-  // ): F[SNCalcResult]
-
 object Itc:
   def apply[F[_]](using ev: Itc[F]): ev.type = ev

--- a/modules/service/src/main/scala/lucuma/itc/ItcImpl.scala
+++ b/modules/service/src/main/scala/lucuma/itc/ItcImpl.scala
@@ -29,62 +29,12 @@ import org.typelevel.log4cats.Logger
 import scala.concurrent.duration.*
 import scala.math.*
 
-trait SignalToNoiseCalculation[F[_]: Applicative] { this: Itc[F] =>
-  // def calculateSignalToNoise(
-  //   graph:           NonEmptyChain[ItcGraphGroup],
-  //   signalToNoiseAt: Option[Wavelength]
-  // ): F[SNCalcResult] =
-  //   (for {
-  //     s2nGraph     <- graph.flatMap(_.graphs).find(_.graphType === GraphType.S2NGraph)
-  //     finalS2NData <- s2nGraph.series
-  //                       .filter(_.seriesType === SeriesDataType.FinalS2NData)
-  //                       .map(_.data)
-  //                       .flatten
-  //                       .some
-  //   } yield {
-  //     def resultFromDouble(d: Double): SNCalcResult =
-  //       SignalToNoise.FromBigDecimalRounding
-  //         .getOption(d)
-  //         .fold(SNCalcResult.CalculationError(s"Computed invalid signal-to-noise: $d")) { sn =>
-  //           SNCalcResult.SNCalcSuccess(sn)
-  //         }
-
-  //     val sorted: List[(Double, Double)] = finalS2NData.sortBy(_._1)
-  //     val sn: SNCalcResult               = signalToNoiseAt
-  //       .fold(resultFromDouble(sorted.maxBy(_._2)._2)) { w =>
-  //         val nanos: Double = Wavelength.decimalNanometers.reverseGet(w).doubleValue
-  //         if (nanos < sorted.head._1) SNCalcResult.WavelengthAtBelowRange(w)
-  //         else if (nanos > sorted.last._1) SNCalcResult.WavelengthAtAboveRange(w)
-  //         else
-  //           val index: Int = sorted.indexWhere(_._1 >= nanos)
-  //           sorted.lift(index).fold(SNCalcResult.NoData()) { secondPoint =>
-  //             val (w2, s2) = secondPoint
-  //             if (w2 === nanos) {
-  //               resultFromDouble(s2)
-  //             } else {
-  //               sorted.lift(index - 1) match
-  //                 case Some((w1, s1)) =>
-  //                   // Linear interpolation
-  //                   val sn = (s1 * (w2 - nanos) + s2 * (nanos - w1)) / (w2 - w1)
-  //                   resultFromDouble(sn)
-  //                 case _              =>
-  //                   // We are checking the limits before, this shouldn't happen
-  //                   SNCalcResult.NoData()
-  //             }
-  //           }
-  //       }
-
-  //     sn.pure[F]
-  //   }).getOrElse(SNCalcResult.NoData().pure[F])
-
-}
-
 /** An ITC implementation that calls the OCS2 ITC server remotely. */
 object ItcImpl {
   opaque type ExposureCount = Int
 
   def build[F[_]: MonadThrow: Logger: Trace](itcLocal: FLocalItc[F]): Itc[F] =
-    new Itc[F] with SignalToNoiseCalculation[F] {
+    new Itc[F] {
       val L = Logger[F]
       val T = Trace[F]
 
@@ -128,9 +78,8 @@ object ItcImpl {
             )
           case ObservingMode.ImagingMode.GmosNorth(_, _) |
               ObservingMode.ImagingMode.GmosSouth(_, _) =>
-            MonadThrow[F].raiseError(
+            MonadThrow[F].raiseError:
               new IllegalArgumentException("Imaging mode not supported for graph calculation")
-            )
 
       private def itcGraph(
         target:           TargetData,
@@ -206,167 +155,6 @@ object ItcImpl {
         itcGraph(target, band, observingMode, constraints, exposureDuration, exposureCount).map:
           r => TargetGraphsCalcResult.fromLegacy(r.ccds, r.groups, atWavelength)
 
-      // /**
-      //  * Compute the exposure time and number of exposures required to achieve the desired
-      //  * signal-to-noise under the requested conditions. Only for spectroscopy modes
-      //  */
-      // private def spectroscopy(
-      //   target:          TargetData,
-      //   band:            Band,
-      //   observingMode:   ObservingMode,
-      //   constraints:     ItcObservingConditions,
-      //   signalToNoise:   SignalToNoise,
-      //   signalToNoiseAt: Option[Wavelength]
-      // ): F[NonEmptyChain[IntegrationTime]] = {
-      //   val startExpTime      = BigDecimal(1200.0).withUnit[Second]
-      //   val numberOfExposures = 1
-      //   val requestedSN       = signalToNoise
-      //   val MaxIterations     = 10
-
-      //   // This loops should be necessary only a few times but put a circuit breaker just in case
-      //   def itcStep(
-      //     nExp:       ExposureCount,
-      //     oldNExp:    Int,
-      //     expTime:    Quantity[BigDecimal, Second],
-      //     oldExpTime: Quantity[BigDecimal, Second],
-      //     snr:        SignalToNoise,
-      //     maxTime:    Quantity[BigDecimal, Second],
-      //     s:          legacy.GraphsRemoteResult,
-      //     counter:    NonNegInt
-      //   ): F[IntegrationTime] =
-      //     val totalTime: Quantity[BigDecimal, Second] =
-      //       if (snr === SignalToNoise.Min) TimeSpan.Max.toSeconds.withUnit[Second]
-      //       else
-      //         expTime * nExp
-      //           .withUnit[1] * pow(requestedSN.toBigDecimal.toDouble / snr.toBigDecimal.toDouble, 2)
-      //           .withUnit[1]
-
-      //     val newNExp: BigDecimal = spire.math.ceil((totalTime / maxTime).value)
-
-      //     val newExpTime: BigDecimal =
-      //       spire.math.ceil((totalTime / newNExp.withUnit[1]).value)
-
-      //     val next = NonNegInt.from(counter.value + 1).getOrElse(sys.error("Should not happen"))
-      //     L.info(s"Total time: $totalTime maxTime: $maxTime") *>
-      //       L.info(s"Exp time :$newExpTime s/Num exp $newNExp/iteration $counter") *> {
-      //         if (
-      //           nExp != oldNExp ||
-      //           ((expTime - oldExpTime) > 1.withUnit[Second] || (oldExpTime - expTime) > 1
-      //             .withUnit[Second]) &&
-      //           counter.value < MaxIterations &&
-      //           newExpTime < (pow(2, 63) - 1)
-      //         ) {
-      //           itcGraph(
-      //             target,
-      //             band,
-      //             observingMode,
-      //             constraints,
-      //             newExpTime.withUnit[Second],
-      //             newNExp.toInt,
-      //             next.some
-      //           )
-      //             .flatMap { s =>
-      //               L.debug(s"-> S/N: ${s.maxTotalSNRatio}") *>
-      //                 calculateSignalToNoise(s.groups, signalToNoiseAt).flatMap {
-      //                   case SNCalcResult.SNCalcSuccess(snr) =>
-      //                     itcStep(
-      //                       newNExp.toInt,
-      //                       nExp,
-      //                       newExpTime.withUnit[Second],
-      //                       expTime,
-      //                       snr,
-      //                       maxTime,
-      //                       s,
-      //                       next
-      //                     )
-      //                   case r                               =>
-      //                     MonadThrow[F].raiseError(CalculationError(r.toString))
-      //                 }
-      //             }
-      //         } else {
-      //           (SignalToNoise.FromBigDecimalRounding.getOption(s.maxTotalSNRatio),
-      //            TimeSpan.fromSeconds(newExpTime),
-      //            refineV[Positive](newNExp.toInt).toOption
-      //           ) match {
-      //             case (Some(sn), Some(expTime), Some(count)) =>
-      //               IntegrationTime(expTime, count, sn).pure[F]
-      //             case _                                      =>
-      //               MonadThrow[F].raiseError(
-      //                 CalculationError(
-      //                   "Negative signal to noise or exposure count"
-      //                 )
-      //               )
-      //           }
-      //         }
-      //       }
-      //   end itcStep
-
-      //   L.info(s"Desired S/N $signalToNoise") *>
-      //     L.info(s"Target brightness $target at band $band") *>
-      //     T.span("itc.calctime.spectroscopy") {
-
-      //       itcGraph(
-      //         target,
-      //         band,
-      //         observingMode,
-      //         constraints,
-      //         startExpTime,
-      //         numberOfExposures,
-      //         1.refined[NonNegative].some
-      //       )
-      //         .flatMap { r =>
-      //           val wellHalfFilledSeconds =
-      //             r.maxWellDepth / 2 / r.maxPeakPixelFlux * startExpTime.value
-      //           L.info(
-      //             s"Results CCD wellDepth: ${r.maxWellDepth}, peakPixelFlux: ${r.maxPeakPixelFlux}, totalSNRatio: ${r.maxTotalSNRatio} wellHalfFilledSeconds: $wellHalfFilledSeconds"
-      //           ) *> {
-      //             if (wellHalfFilledSeconds < 1.0) {
-      //               MonadThrow[F].raiseError(SourceTooBright(wellHalfFilledSeconds))
-      //             } else {
-      //               val maxTime = startExpTime.value.min(wellHalfFilledSeconds)
-      //               calculateSignalToNoise(r.groups, signalToNoiseAt)
-      //                 .flatMap {
-      //                   // degenerate case where the ITC cannot compute a S/N
-      //                   case SNCalcResult.SNCalcSuccess(snr) if snr.toBigDecimal <= 0.0 =>
-      //                     MonadThrow[F].raiseError(
-      //                       CalculationError("No signal can be achieved")
-      //                     )
-      //                   case SNCalcResult.SNCalcSuccess(snr)                            =>
-      //                     itcStep(
-      //                       numberOfExposures,
-      //                       0,
-      //                       startExpTime,
-      //                       BigDecimal(0).withUnit[Second],
-      //                       snr,
-      //                       maxTime.withUnit[Second],
-      //                       r,
-      //                       0.refined
-      //                     )
-      //                   case SNCalcResult.WavelengthAtAboveRange(w)                     =>
-      //                     MonadThrow[F].raiseError(
-      //                       CalculationError(
-      //                         f"S/N at ${Wavelength.decimalNanometers.reverseGet(w)}%.0f nm above range"
-      //                       )
-      //                     )
-      //                   case SNCalcResult.WavelengthAtBelowRange(w)                     =>
-      //                     MonadThrow[F].raiseError(
-      //                       CalculationError(
-      //                         f"S/N at ${Wavelength.decimalNanometers.reverseGet(w)}%.0f nm below range"
-      //                       )
-      //                     )
-      //                   case r                                                          =>
-      //                     MonadThrow[F].raiseError(CalculationError(r.toString))
-      //                 }
-
-      //             }
-      //           }
-
-      //         }
-      //         .map(NonEmptyChain.one)
-      //     }
-
-      // }
-
       /**
        * Compute the exposure time and number of exposures required to achieve the desired
        * signal-to-noise under the requested conditions. Only for spectroscopy modes.
@@ -378,13 +166,12 @@ object ItcImpl {
         observingMode: ObservingMode.SpectroscopyMode,
         constraints:   ItcObservingConditions,
         signalToNoise: SignalToNoise
-        // signalToNoiseAt: Wavelength
       ): F[NonEmptyChain[IntegrationTime]] =
         for {
           _ <- L.info(s"Desired S/N $signalToNoise")
           _ <- L.info(s"Target $target at band $band")
           r <-
-            T.span("itc.calctime.spectroscopy-integration-time") {
+            T.span("itc.calctime.spectroscopy-integration-time"):
               itcIntegrationTime(
                 target,
                 atWavelength,
@@ -393,7 +180,6 @@ object ItcImpl {
                 constraints,
                 signalToNoise
               )
-            }
           t <- calculationResults(r)
         } yield t
 
@@ -426,13 +212,9 @@ object ItcImpl {
           TimeSpan
             .fromSeconds(r.exposureTime)
             .map(expTime => IntegrationTime(expTime, r.exposureCount, r.signalToNoise).pure[F])
-            .getOrElse {
-              MonadThrow[F].raiseError(
-                CalculationError(
-                  s"Negative exposure time ${r.exposureTime}"
-                )
-              )
-            }
+            .getOrElse:
+              MonadThrow[F].raiseError:
+                CalculationError(s"Negative exposure time ${r.exposureTime}")
         )
 
       /**
@@ -449,9 +231,8 @@ object ItcImpl {
         for {
           _ <- L.info(s"Desired S/N $signalToNoise")
           _ <- L.info(s"Target $target  at band $band")
-          r <- T.span("itc.calctime.spectroscopy-exp-time-at") {
+          r <- T.span("itc.calctime.spectroscopy-exp-time-at"):
                  imagingLegacy(target, band, observingMode, constraints, signalToNoise)
-               }
           t <- calculationResults(r)
         } yield t
 

--- a/modules/service/src/main/scala/lucuma/itc/ItcImpl.scala
+++ b/modules/service/src/main/scala/lucuma/itc/ItcImpl.scala
@@ -13,13 +13,14 @@ import coulomb.syntax.*
 import coulomb.units.si.*
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.numeric.PosInt
+import io.circe.Json
 import io.circe.syntax.*
 import lucuma.core.enums.Band
 import lucuma.core.math.SignalToNoise
 import lucuma.core.math.Wavelength
 import lucuma.core.util.TimeSpan
-import lucuma.itc.legacy.IntegrationTimeRemoteResult
 import lucuma.itc.legacy.FLocalItc
+import lucuma.itc.legacy.IntegrationTimeRemoteResult
 import lucuma.itc.search.ObservingMode
 import lucuma.itc.search.TargetData
 import natchez.Trace
@@ -27,7 +28,6 @@ import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.*
 import scala.math.*
-import io.circe.Json
 
 trait SignalToNoiseCalculation[F[_]: Applicative] { this: Itc[F] =>
   // def calculateSignalToNoise(

--- a/modules/service/src/main/scala/lucuma/itc/TargetGraphsCalcResult.scala
+++ b/modules/service/src/main/scala/lucuma/itc/TargetGraphsCalcResult.scala
@@ -23,7 +23,7 @@ object TargetGraphsCalcResult:
   def fromLegacy(
     ccds:           NonEmptyChain[ItcRemoteCcd],
     originalGraphs: NonEmptyChain[ItcGraphGroup],
-    wavelength:     Wavelength
+    atWavelength:   Wavelength
   ): TargetGraphsCalcResult = {
     val graphs: NonEmptyChain[ItcGraphGroup] =
       originalGraphs.map: graph =>
@@ -57,7 +57,7 @@ object TargetGraphsCalcResult:
         .zip(ccds.toList)
         .map: (sn, _) =>
           sn.data
-            .find(_._1 >= wavelength.toNanometers.value.value)
+            .find(_._1 >= atWavelength.toNanometers.value.value)
             .map(_._2)
         .flattenOption
         .headOption

--- a/modules/service/src/main/scala/lucuma/itc/input/GmosNSpectroscopyInput.scala
+++ b/modules/service/src/main/scala/lucuma/itc/input/GmosNSpectroscopyInput.scala
@@ -8,17 +8,19 @@ import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosNorthFpu
 import lucuma.core.enums.GmosNorthGrating
 import lucuma.core.enums.GmosRoi
+import lucuma.core.math.Wavelength
 import lucuma.core.model.sequence.gmos.GmosCcdMode
 import lucuma.core.model.sequence.gmos.GmosFpuMask
 import lucuma.odb.graphql.binding.*
 import lucuma.odb.graphql.input.*
 
 case class GmosNSpectroscopyInput(
-  grating: GmosNorthGrating,
-  fpu:     GmosFpuMask[GmosNorthFpu],
-  filter:  Option[GmosNorthFilter],
-  ccdMode: Option[GmosCcdMode],
-  roi:     Option[GmosRoi]
+  centralWavelength: Wavelength,
+  grating:           GmosNorthGrating,
+  fpu:               GmosFpuMask[GmosNorthFpu],
+  filter:            Option[GmosNorthFilter],
+  ccdMode:           Option[GmosCcdMode],
+  roi:               Option[GmosRoi]
 ) extends InstrumentModesInput
 
 object GmosNSpectroscopyInput {
@@ -26,13 +28,14 @@ object GmosNSpectroscopyInput {
   def binding: Matcher[GmosNSpectroscopyInput] =
     ObjectFieldsBinding.rmap {
       case List(
+            WavelengthInput.Binding("centralWavelength", centralWavelength),
             GmosNorthGratingBinding("grating", grating),
             GmosNorthFpuInput.Binding("fpu", fpu),
             GmosNorthFilterBinding.Option("filter", filter),
             GmosCcdModeInput.Binding.Option("ccdMode", ccdMode),
             GmosRoiBinding.Option("roi", roi)
           ) =>
-        (grating, fpu, filter, ccdMode, roi).parMapN(apply)
+        (centralWavelength, grating, fpu, filter, ccdMode, roi).parMapN(apply)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/itc/input/GmosSSpectroscopyInput.scala
+++ b/modules/service/src/main/scala/lucuma/itc/input/GmosSSpectroscopyInput.scala
@@ -8,17 +8,19 @@ import lucuma.core.enums.GmosRoi
 import lucuma.core.enums.GmosSouthFilter
 import lucuma.core.enums.GmosSouthFpu
 import lucuma.core.enums.GmosSouthGrating
+import lucuma.core.math.Wavelength
 import lucuma.core.model.sequence.gmos.GmosCcdMode
 import lucuma.core.model.sequence.gmos.GmosFpuMask
 import lucuma.odb.graphql.binding.*
 import lucuma.odb.graphql.input.*
 
 case class GmosSSpectroscopyInput(
-  grating: GmosSouthGrating,
-  fpu:     GmosFpuMask[GmosSouthFpu],
-  filter:  Option[GmosSouthFilter],
-  ccdMode: Option[GmosCcdMode],
-  roi:     Option[GmosRoi]
+  centralWavelength: Wavelength,
+  grating:           GmosSouthGrating,
+  fpu:               GmosFpuMask[GmosSouthFpu],
+  filter:            Option[GmosSouthFilter],
+  ccdMode:           Option[GmosCcdMode],
+  roi:               Option[GmosRoi]
 ) extends InstrumentModesInput
 
 object GmosSSpectroscopyInput {
@@ -26,13 +28,14 @@ object GmosSSpectroscopyInput {
   def binding: Matcher[GmosSSpectroscopyInput] =
     ObjectFieldsBinding.rmap {
       case List(
+            WavelengthInput.Binding("centralWavelength", centralWavelength),
             GmosSouthGratingBinding("grating", grating),
             GmosSouthFpuInput.Binding("fpu", fpu),
             GmosSouthFilterBinding.Option("filter", filter),
             GmosCcdModeInput.Binding.Option("ccdMode", ccdMode),
             GmosRoiBinding.Option("roi", roi)
           ) =>
-        (grating, fpu, filter, ccdMode, roi).parMapN(apply)
+        (centralWavelength, grating, fpu, filter, ccdMode, roi).parMapN(apply)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/itc/input/ImagingIntegrationTimeInput.scala
+++ b/modules/service/src/main/scala/lucuma/itc/input/ImagingIntegrationTimeInput.scala
@@ -10,7 +10,7 @@ import lucuma.odb.graphql.binding.*
 import lucuma.odb.graphql.input.*
 
 case class ImagingIntegrationTimeInput(
-  wavelength:    Wavelength,
+  atWavelength:  Wavelength,
   signalToNoise: SignalToNoise,
   asterism:      List[TargetDataInput],
   constraints:   ConstraintSetInput,

--- a/modules/service/src/main/scala/lucuma/itc/input/ImagingIntegrationTimeInput.scala
+++ b/modules/service/src/main/scala/lucuma/itc/input/ImagingIntegrationTimeInput.scala
@@ -22,7 +22,7 @@ object ImagingIntegrationTimeInput {
   def binding: Matcher[ImagingIntegrationTimeInput] =
     ObjectFieldsBinding.rmap {
       case List(
-            WavelengthInput.Binding("wavelength", wavelength),
+            WavelengthInput.Binding("atWavelength", wavelength),
             SignalToNoiseBinding("signalToNoise", signalToNoise),
             TargetDataInput.binding.List("asterism", asterism),
             ConstraintSetInput.Binding("constraints", constraints),

--- a/modules/service/src/main/scala/lucuma/itc/input/SpectroscopyGraphsInput.scala
+++ b/modules/service/src/main/scala/lucuma/itc/input/SpectroscopyGraphsInput.scala
@@ -12,7 +12,7 @@ import lucuma.odb.graphql.binding.*
 import lucuma.odb.graphql.input.*
 
 case class SpectroscopyGraphsInput(
-  wavelength:         Wavelength,
+  atWavelength:       Wavelength,
   exposureTime:       TimeSpan,
   exposureCount:      PosInt,
   asterism:           List[TargetDataInput],
@@ -26,7 +26,7 @@ object SpectroscopyGraphsInput {
   def binding: Matcher[SpectroscopyGraphsInput] =
     ObjectFieldsBinding.rmap {
       case List(
-            WavelengthInput.Binding("wavelength", wavelength),
+            WavelengthInput.Binding("atWavelength", wavelength),
             TimeSpanInput.Binding("exposureTime", exposureTime),
             PosIntBinding("exposureCount", exposureCount),
             TargetDataInput.binding.List("asterism", asterism),

--- a/modules/service/src/main/scala/lucuma/itc/input/SpectroscopyGraphsInput.scala
+++ b/modules/service/src/main/scala/lucuma/itc/input/SpectroscopyGraphsInput.scala
@@ -13,7 +13,6 @@ import lucuma.odb.graphql.input.*
 
 case class SpectroscopyGraphsInput(
   wavelength:         Wavelength,
-  signalToNoiseAt:    Option[Wavelength],
   exposureTime:       TimeSpan,
   exposureCount:      PosInt,
   asterism:           List[TargetDataInput],
@@ -28,7 +27,6 @@ object SpectroscopyGraphsInput {
     ObjectFieldsBinding.rmap {
       case List(
             WavelengthInput.Binding("wavelength", wavelength),
-            WavelengthInput.Binding.Option("signalToNoiseAt", signalToNoiseAt),
             TimeSpanInput.Binding("exposureTime", exposureTime),
             PosIntBinding("exposureCount", exposureCount),
             TargetDataInput.binding.List("asterism", asterism),
@@ -36,15 +34,8 @@ object SpectroscopyGraphsInput {
             InstrumentModesInput.binding("mode", mode),
             SignificantFiguresInput.binding.Option("significantFigures", significantFigures)
           ) =>
-        (wavelength,
-         signalToNoiseAt,
-         exposureTime,
-         exposureCount,
-         asterism,
-         constraints,
-         mode,
-         significantFigures
-        ).parMapN(apply)
+        (wavelength, exposureTime, exposureCount, asterism, constraints, mode, significantFigures)
+          .parMapN(apply)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/itc/input/SpectroscopyIntegrationTimeInput.scala
+++ b/modules/service/src/main/scala/lucuma/itc/input/SpectroscopyIntegrationTimeInput.scala
@@ -11,7 +11,7 @@ import lucuma.odb.graphql.binding.*
 import lucuma.odb.graphql.input.*
 
 sealed trait SpectroscopyTimeInput {
-  def wavelength: Wavelength
+  def atWavelength: Wavelength
   def signalToNoise: SignalToNoise
   def asterism: List[TargetDataInput]
   def constraints: ConstraintSetInput
@@ -22,10 +22,10 @@ object SpectroscopyTimeInput:
   def unapply(
     arg: SpectroscopyTimeInput
   ): (Wavelength, SignalToNoise, List[TargetDataInput], ConstraintSetInput, InstrumentModesInput) =
-    (arg.wavelength, arg.signalToNoise, arg.asterism, arg.constraints, arg.mode)
+    (arg.atWavelength, arg.signalToNoise, arg.asterism, arg.constraints, arg.mode)
 
 case class SpectroscopyIntegrationTimeInput(
-  wavelength:    Wavelength,
+  atWavelength:  Wavelength,
   signalToNoise: SignalToNoise,
   asterism:      List[TargetDataInput],
   constraints:   ConstraintSetInput,
@@ -37,7 +37,7 @@ object SpectroscopyIntegrationTimeInput {
   def binding: Matcher[SpectroscopyIntegrationTimeInput] =
     ObjectFieldsBinding.rmap {
       case List(
-            WavelengthInput.Binding("wavelength", wavelength),
+            WavelengthInput.Binding("atWavelength", wavelength),
             SignalToNoiseBinding("signalToNoise", signalToNoise),
             TargetDataInput.binding.List("asterism", asterism),
             ConstraintSetInput.Binding("constraints", constraints),
@@ -49,7 +49,7 @@ object SpectroscopyIntegrationTimeInput {
 }
 
 case class SpectroscopyIntegrationTimeAndGraphsInput(
-  wavelength:         Wavelength,
+  atWavelength:       Wavelength,
   signalToNoise:      SignalToNoise,
   asterism:           List[TargetDataInput],
   constraints:        ConstraintSetInput,
@@ -62,7 +62,7 @@ object SpectroscopyIntegrationTimeAndGraphsInput {
   def binding: Matcher[SpectroscopyIntegrationTimeAndGraphsInput] =
     ObjectFieldsBinding.rmap {
       case List(
-            WavelengthInput.Binding("wavelength", wavelength),
+            WavelengthInput.Binding("atWavelength", wavelength),
             SignalToNoiseBinding("signalToNoise", signalToNoise),
             TargetDataInput.binding.List("asterism", asterism),
             ConstraintSetInput.Binding("constraints", constraints),

--- a/modules/service/src/main/scala/lucuma/itc/input/SpectroscopyIntegrationTimeInput.scala
+++ b/modules/service/src/main/scala/lucuma/itc/input/SpectroscopyIntegrationTimeInput.scala
@@ -13,37 +13,23 @@ import lucuma.odb.graphql.input.*
 sealed trait SpectroscopyTimeInput {
   def wavelength: Wavelength
   def signalToNoise: SignalToNoise
-  def signalToNoiseAt: Option[Wavelength]
   def asterism: List[TargetDataInput]
   def constraints: ConstraintSetInput
   def mode: InstrumentModesInput
 }
 
 object SpectroscopyTimeInput:
-  def unapply(arg: SpectroscopyTimeInput): (
-    Wavelength,
-    SignalToNoise,
-    Option[Wavelength],
-    List[TargetDataInput],
-    ConstraintSetInput,
-    InstrumentModesInput
-  ) =
-    (
-      arg.wavelength,
-      arg.signalToNoise,
-      arg.signalToNoiseAt,
-      arg.asterism,
-      arg.constraints,
-      arg.mode
-    )
+  def unapply(
+    arg: SpectroscopyTimeInput
+  ): (Wavelength, SignalToNoise, List[TargetDataInput], ConstraintSetInput, InstrumentModesInput) =
+    (arg.wavelength, arg.signalToNoise, arg.asterism, arg.constraints, arg.mode)
 
 case class SpectroscopyIntegrationTimeInput(
-  wavelength:      Wavelength,
-  signalToNoise:   SignalToNoise,
-  signalToNoiseAt: Option[Wavelength],
-  asterism:        List[TargetDataInput],
-  constraints:     ConstraintSetInput,
-  mode:            InstrumentModesInput
+  wavelength:    Wavelength,
+  signalToNoise: SignalToNoise,
+  asterism:      List[TargetDataInput],
+  constraints:   ConstraintSetInput,
+  mode:          InstrumentModesInput
 ) extends SpectroscopyTimeInput
 
 object SpectroscopyIntegrationTimeInput {
@@ -53,14 +39,11 @@ object SpectroscopyIntegrationTimeInput {
       case List(
             WavelengthInput.Binding("wavelength", wavelength),
             SignalToNoiseBinding("signalToNoise", signalToNoise),
-            WavelengthInput.Binding.Option("signalToNoiseAt", signalToNoiseAt),
             TargetDataInput.binding.List("asterism", asterism),
             ConstraintSetInput.Binding("constraints", constraints),
             InstrumentModesInput.binding("mode", mode)
           ) =>
-        (wavelength, signalToNoise, signalToNoiseAt, asterism, constraints, mode).parMapN(
-          apply
-        )
+        (wavelength, signalToNoise, asterism, constraints, mode).parMapN(apply)
     }
 
 }
@@ -68,7 +51,6 @@ object SpectroscopyIntegrationTimeInput {
 case class SpectroscopyIntegrationTimeAndGraphsInput(
   wavelength:         Wavelength,
   signalToNoise:      SignalToNoise,
-  signalToNoiseAt:    Option[Wavelength],
   asterism:           List[TargetDataInput],
   constraints:        ConstraintSetInput,
   mode:               InstrumentModesInput,
@@ -82,20 +64,12 @@ object SpectroscopyIntegrationTimeAndGraphsInput {
       case List(
             WavelengthInput.Binding("wavelength", wavelength),
             SignalToNoiseBinding("signalToNoise", signalToNoise),
-            WavelengthInput.Binding.Option("signalToNoiseAt", signalToNoiseAt),
             TargetDataInput.binding.List("asterism", asterism),
             ConstraintSetInput.Binding("constraints", constraints),
             InstrumentModesInput.binding("mode", mode),
             SignificantFiguresInput.binding.Option("significantFigures", significantFigures)
           ) =>
-        (wavelength,
-         signalToNoise,
-         signalToNoiseAt,
-         asterism,
-         constraints,
-         mode,
-         significantFigures
-        ).parMapN(apply)
+        (wavelength, signalToNoise, asterism, constraints, mode, significantFigures).parMapN(apply)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/itc/legacy/FLocalItc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/FLocalItc.scala
@@ -30,8 +30,8 @@ case class FLocalItc[F[_]: Async](itcLocal: LocalItc):
         }
     }
 
-  def calculateExposureTime(jsonParams: String): F[ExposureTimeRemoteResult] =
-    (F.cede *> F.delay(itcLocal.calculateExposureTime(jsonParams)).guarantee(F.cede)).flatMap {
+  def calculateIntegrationTime(jsonParams: String): F[IntegrationTimeRemoteResult] =
+    (F.cede *> F.delay(itcLocal.calculateIntegrationTime(jsonParams)).guarantee(F.cede)).flatMap {
       case Right(result) => F.pure(result)
       case Left(msg)     =>
         msg match {

--- a/modules/service/src/main/scala/lucuma/itc/legacy/ItcRemoteGraphResult.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/ItcRemoteGraphResult.scala
@@ -24,4 +24,4 @@ case class ExposureCalculation(
   signalToNoise: SignalToNoise
 )
 
-case class ExposureTimeRemoteResult(exposureCalculation: NonEmptyChain[ExposureCalculation])
+case class IntegrationTimeRemoteResult(exposureCalculation: NonEmptyChain[ExposureCalculation])

--- a/modules/service/src/main/scala/lucuma/itc/legacy/LocalItc.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/LocalItc.scala
@@ -66,14 +66,16 @@ case class LocalItc(classLoader: ClassLoader):
   /**
    * This method does a call to the method ItcCalculation.calculate via reflection.
    */
-  def calculateExposureTime(jsonParams: String): Either[List[String], ExposureTimeRemoteResult] =
+  def calculateIntegrationTime(
+    jsonParams: String
+  ): Either[List[String], IntegrationTimeRemoteResult] =
     val res = calculateExposureTimeMethod
       .invoke(null, jsonParams) // null as it is a static method
       .asInstanceOf[String]
 
     res match
       case LegacyRight(result)    =>
-        decode[legacy.ExposureTimeRemoteResult](result).leftMap { e =>
+        decode[legacy.IntegrationTimeRemoteResult](result).leftMap { e =>
           List(e.getMessage())
         }
       case LegacyLeft(result)     =>

--- a/modules/service/src/main/scala/lucuma/itc/legacy/codecs.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/codecs.scala
@@ -97,22 +97,25 @@ private val encodeGmosNorthImaging: Encoder[ObservingMode.ImagingMode.GmosNorth]
     def apply(a: ObservingMode.ImagingMode.GmosNorth): Json =
       Json.obj(
         // Translate observing mode to OCS2 style
-        "filter"          -> Json.obj(
+        "centralWavelength" -> Json.fromString(
+          s"${Wavelength.decimalNanometers.reverseGet(a.centralWavelength)} nm"
+        ),
+        "filter"            -> Json.obj(
           "FilterNorth" ->
             Json.fromString(a.filter.ocs2Tag)
         ),
-        "grating"         -> Json.obj("DisperserNorth" -> "MIRROR".asJson),
-        "fpMask"          -> Json.obj("FPUnitNorth" -> "FPU_NONE".asJson),
-        "spectralBinning" -> Json.fromInt(a.ccdMode.map(_.xBin).getOrElse(GmosXBinning.Two).count),
-        "site"            -> Json.fromString("GN"),
-        "ccdType"         -> Json.fromString("HAMAMATSU"),
-        "ampReadMode"     -> Json.fromString(
+        "grating"           -> Json.obj("DisperserNorth" -> "MIRROR".asJson),
+        "fpMask"            -> Json.obj("FPUnitNorth" -> "FPU_NONE".asJson),
+        "spectralBinning"   -> Json.fromInt(a.ccdMode.map(_.xBin).getOrElse(GmosXBinning.Two).count),
+        "site"              -> Json.fromString("GN"),
+        "ccdType"           -> Json.fromString("HAMAMATSU"),
+        "ampReadMode"       -> Json.fromString(
           a.ccdMode.map(_.ampReadMode).getOrElse(GmosAmpReadMode.Fast).tag.toUpperCase
         ),
-        "builtinROI"      -> Json.fromString("FULL_FRAME"),
-        "spatialBinning"  -> Json.fromInt(a.ccdMode.map(_.yBin).getOrElse(GmosYBinning.Two).count),
-        "customSlitWidth" -> Json.Null,
-        "ampGain"         -> Json.fromString(
+        "builtinROI"        -> Json.fromString("FULL_FRAME"),
+        "spatialBinning"    -> Json.fromInt(a.ccdMode.map(_.yBin).getOrElse(GmosYBinning.Two).count),
+        "customSlitWidth"   -> Json.Null,
+        "ampGain"           -> Json.fromString(
           a.ccdMode.map(_.ampGain).getOrElse(GmosAmpGain.Low).tag.toUpperCase
         )
       )

--- a/modules/service/src/main/scala/lucuma/itc/legacy/codecs.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/codecs.scala
@@ -463,19 +463,19 @@ given Decoder[ExposureCalculation] = (c: HCursor) =>
           refineV[Positive](_).leftMap(e => DecodingFailure(e, c.downField("exposures").history))
   yield ExposureCalculation(time, count, sn)
 
-given Decoder[ExposureTimeRemoteResult] = (c: HCursor) =>
-  val spec: Option[Decoder.Result[ExposureTimeRemoteResult]] =
+given Decoder[IntegrationTimeRemoteResult] = (c: HCursor) =>
+  val spec: Option[Decoder.Result[IntegrationTimeRemoteResult]] =
     c.downField("ItcSpectroscopyResult")
       .downField("exposureCalculation")
       .success
       .map:
         _.as[ExposureCalculation]
-          .map(c => ExposureTimeRemoteResult(NonEmptyChain.one(c)))
+          .map(c => IntegrationTimeRemoteResult(NonEmptyChain.one(c)))
 
-  val img: Decoder.Result[ExposureTimeRemoteResult] =
+  val img: Decoder.Result[IntegrationTimeRemoteResult] =
     c.downField("ItcImagingResult")
       .downField("exposureCalculation")
       .as[NonEmptyChain[ExposureCalculation]]
-      .map(c => ExposureTimeRemoteResult(c))
+      .map(c => IntegrationTimeRemoteResult(c))
 
   spec.getOrElse(img)

--- a/modules/service/src/main/scala/lucuma/itc/legacy/codecs.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/codecs.scala
@@ -66,7 +66,7 @@ private val encodeGmosNorthSpectroscopy: Encoder[ObservingMode.SpectroscopyMode.
       Json.obj(
         // Translate observing mode to OCS2 style
         "centralWavelength" -> Json.fromString(
-          s"${Wavelength.decimalNanometers.reverseGet(a.λ)} nm"
+          s"${Wavelength.decimalNanometers.reverseGet(a.centralWavelength)} nm"
         ),
         "filter"            -> Json.obj(
           "FilterNorth" -> a.filter.fold[Json](Json.fromString("NONE"))(r =>
@@ -97,25 +97,22 @@ private val encodeGmosNorthImaging: Encoder[ObservingMode.ImagingMode.GmosNorth]
     def apply(a: ObservingMode.ImagingMode.GmosNorth): Json =
       Json.obj(
         // Translate observing mode to OCS2 style
-        "centralWavelength" -> Json.fromString(
-          s"${Wavelength.decimalNanometers.reverseGet(a.λ)} nm"
-        ),
-        "filter"            -> Json.obj(
+        "filter"          -> Json.obj(
           "FilterNorth" ->
             Json.fromString(a.filter.ocs2Tag)
         ),
-        "grating"           -> Json.obj("DisperserNorth" -> "MIRROR".asJson),
-        "fpMask"            -> Json.obj("FPUnitNorth" -> "FPU_NONE".asJson),
-        "spectralBinning"   -> Json.fromInt(a.ccdMode.map(_.xBin).getOrElse(GmosXBinning.Two).count),
-        "site"              -> Json.fromString("GN"),
-        "ccdType"           -> Json.fromString("HAMAMATSU"),
-        "ampReadMode"       -> Json.fromString(
+        "grating"         -> Json.obj("DisperserNorth" -> "MIRROR".asJson),
+        "fpMask"          -> Json.obj("FPUnitNorth" -> "FPU_NONE".asJson),
+        "spectralBinning" -> Json.fromInt(a.ccdMode.map(_.xBin).getOrElse(GmosXBinning.Two).count),
+        "site"            -> Json.fromString("GN"),
+        "ccdType"         -> Json.fromString("HAMAMATSU"),
+        "ampReadMode"     -> Json.fromString(
           a.ccdMode.map(_.ampReadMode).getOrElse(GmosAmpReadMode.Fast).tag.toUpperCase
         ),
-        "builtinROI"        -> Json.fromString("FULL_FRAME"),
-        "spatialBinning"    -> Json.fromInt(a.ccdMode.map(_.yBin).getOrElse(GmosYBinning.Two).count),
-        "customSlitWidth"   -> Json.Null,
-        "ampGain"           -> Json.fromString(
+        "builtinROI"      -> Json.fromString("FULL_FRAME"),
+        "spatialBinning"  -> Json.fromInt(a.ccdMode.map(_.yBin).getOrElse(GmosYBinning.Two).count),
+        "customSlitWidth" -> Json.Null,
+        "ampGain"         -> Json.fromString(
           a.ccdMode.map(_.ampGain).getOrElse(GmosAmpGain.Low).tag.toUpperCase
         )
       )
@@ -127,7 +124,7 @@ private val encodeGmosSouthSpectroscopy: Encoder[ObservingMode.SpectroscopyMode.
       Json.obj(
         // Translate observing mode to OCS2 style
         "centralWavelength" -> Json.fromString(
-          s"${Wavelength.decimalNanometers.reverseGet(a.λ)} nm"
+          s"${Wavelength.decimalNanometers.reverseGet(a.centralWavelength)} nm"
         ),
         "filter"            -> Json.obj(
           "FilterSouth" -> a.filter.fold[Json](Json.fromString("NONE"))(r =>
@@ -158,25 +155,22 @@ private val encodeGmosSouthImaging: Encoder[ObservingMode.ImagingMode.GmosSouth]
     def apply(a: ObservingMode.ImagingMode.GmosSouth): Json =
       Json.obj(
         // Translate observing mode to OCS2 style
-        "centralWavelength" -> Json.fromString(
-          s"${Wavelength.decimalNanometers.reverseGet(a.λ)} nm"
-        ),
-        "filter"            -> Json.obj(
+        "filter"          -> Json.obj(
           "FilterSouth" ->
             Json.fromString(a.filter.ocs2Tag)
         ),
-        "grating"           -> Json.obj("DisperserSouth" -> "MIRROR".asJson),
-        "fpMask"            -> Json.obj("FPUnitSouth" -> "FPU_NONE".asJson),
-        "spectralBinning"   -> Json.fromInt(a.ccdMode.map(_.xBin).getOrElse(GmosXBinning.Two).count),
-        "site"              -> Json.fromString("GS"),
-        "ccdType"           -> Json.fromString("HAMAMATSU"),
-        "ampReadMode"       -> Json.fromString(
+        "grating"         -> Json.obj("DisperserSouth" -> "MIRROR".asJson),
+        "fpMask"          -> Json.obj("FPUnitSouth" -> "FPU_NONE".asJson),
+        "spectralBinning" -> Json.fromInt(a.ccdMode.map(_.xBin).getOrElse(GmosXBinning.Two).count),
+        "site"            -> Json.fromString("GS"),
+        "ccdType"         -> Json.fromString("HAMAMATSU"),
+        "ampReadMode"     -> Json.fromString(
           a.ccdMode.map(_.ampReadMode).getOrElse(GmosAmpReadMode.Fast).tag.toUpperCase
         ),
-        "builtinROI"        -> Json.fromString("FULL_FRAME"),
-        "spatialBinning"    -> Json.fromInt(a.ccdMode.map(_.yBin).getOrElse(GmosYBinning.Two).count),
-        "customSlitWidth"   -> Json.Null,
-        "ampGain"           -> Json.fromString(
+        "builtinROI"      -> Json.fromString("FULL_FRAME"),
+        "spatialBinning"  -> Json.fromInt(a.ccdMode.map(_.yBin).getOrElse(GmosYBinning.Two).count),
+        "customSlitWidth" -> Json.Null,
+        "ampGain"         -> Json.fromString(
           a.ccdMode.map(_.ampGain).getOrElse(GmosAmpGain.Low).tag.toUpperCase
         )
       )

--- a/modules/service/src/main/scala/lucuma/itc/legacy/package.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/package.scala
@@ -72,6 +72,7 @@ def spectroscopyGraphParams(
 
 def spectroscopyExposureTimeParams(
   target:        TargetData,
+  atWavelength:  Wavelength,
   band:          Band,
   observingMode: ObservingMode.SpectroscopyMode,
   conditions:    ItcObservingConditions,
@@ -84,7 +85,7 @@ def spectroscopyExposureTimeParams(
         ItcObservationDetails.CalculationMethod.SignalToNoise.SpectroscopyWithSNAt(
           sigma = sigma.toBigDecimal.toDouble,
           coadds = None,
-          wavelength = observingMode.λ,
+          wavelength = atWavelength,
           sourceFraction = 1.0,
           ditherOffset = Angle.Angle0
         ),

--- a/modules/service/src/main/scala/lucuma/itc/legacy/package.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/package.scala
@@ -75,7 +75,8 @@ def spectroscopyExposureTimeParams(
   band:          Band,
   observingMode: ObservingMode.SpectroscopyMode,
   conditions:    ItcObservingConditions,
-  sigma:         SignalToNoise
+  sigma:         SignalToNoise,
+  wavelength:    Wavelength
 ): ItcParameters =
   ItcParameters(
     source = ItcSourceDefinition(target, band),
@@ -84,7 +85,7 @@ def spectroscopyExposureTimeParams(
         ItcObservationDetails.CalculationMethod.SignalToNoise.SpectroscopyWithSNAt(
           sigma = sigma.toBigDecimal.toDouble,
           coadds = None,
-          wavelength = observingMode.λ,
+          wavelength = wavelength,
           sourceFraction = 1.0,
           ditherOffset = Angle.Angle0
         ),

--- a/modules/service/src/main/scala/lucuma/itc/legacy/package.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/package.scala
@@ -43,7 +43,7 @@ object ItcInstrumentDetails:
     apply(mode)
 
 /** Convert model types into OCS2 ITC-compatible types for a spectroscopy request. */
-def spectroscopyParams(
+def spectroscopyGraphParams(
   target:           TargetData,
   band:             Band,
   observingMode:    ObservingMode,
@@ -70,13 +70,12 @@ def spectroscopyParams(
     instrument = ItcInstrumentDetails.fromObservingMode(observingMode)
   )
 
-def spectroscopyWithSNAtParams(
+def spectroscopyExposureTimeParams(
   target:        TargetData,
   band:          Band,
-  observingMode: ObservingMode,
+  observingMode: ObservingMode.SpectroscopyMode,
   conditions:    ItcObservingConditions,
-  sigma:         SignalToNoise,
-  wavelength:    Wavelength
+  sigma:         SignalToNoise
 ): ItcParameters =
   ItcParameters(
     source = ItcSourceDefinition(target, band),
@@ -85,7 +84,7 @@ def spectroscopyWithSNAtParams(
         ItcObservationDetails.CalculationMethod.SignalToNoise.SpectroscopyWithSNAt(
           sigma = sigma.toBigDecimal.toDouble,
           coadds = None,
-          wavelength = wavelength,
+          wavelength = observingMode.λ,
           sourceFraction = 1.0,
           ditherOffset = Angle.Angle0
         ),

--- a/modules/service/src/main/scala/lucuma/itc/legacy/package.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/package.scala
@@ -75,8 +75,7 @@ def spectroscopyExposureTimeParams(
   band:          Band,
   observingMode: ObservingMode.SpectroscopyMode,
   conditions:    ItcObservingConditions,
-  sigma:         SignalToNoise,
-  wavelength:    Wavelength
+  sigma:         SignalToNoise
 ): ItcParameters =
   ItcParameters(
     source = ItcSourceDefinition(target, band),
@@ -85,7 +84,7 @@ def spectroscopyExposureTimeParams(
         ItcObservationDetails.CalculationMethod.SignalToNoise.SpectroscopyWithSNAt(
           sigma = sigma.toBigDecimal.toDouble,
           coadds = None,
-          wavelength = wavelength,
+          wavelength = observingMode.λ,
           sourceFraction = 1.0,
           ditherOffset = Angle.Angle0
         ),

--- a/modules/service/src/main/scala/lucuma/itc/search/ObservingMode.scala
+++ b/modules/service/src/main/scala/lucuma/itc/search/ObservingMode.scala
@@ -106,7 +106,7 @@ object ObservingMode {
           ("instrument", Json.fromString(a.instrument.longName.toUpperCase.replace(" ", "_"))),
           ("resolution", Json.fromInt(a.resolution.toInt)),
           ("params", GmosNSpectroscopyParams(a.disperser, a.fpu, a.filter).asJson),
-          ("wavelength", a.centralWavelength.asJson)
+          ("centralWavelength", a.centralWavelength.asJson)
         )
 
     case class GmosSouth(
@@ -138,7 +138,7 @@ object ObservingMode {
           ("instrument", Json.fromString(a.instrument.longName.toUpperCase.replace(" ", "_"))),
           ("resolution", Json.fromInt(a.resolution.toInt)),
           ("params", GmosSSpectroscopyParams(a.disperser, a.fpu, a.filter).asJson),
-          ("wavelength", a.centralWavelength.asJson)
+          ("centralWavelength", a.centralWavelength.asJson)
         )
 
   }

--- a/modules/service/src/main/scala/lucuma/itc/search/ObservingMode.scala
+++ b/modules/service/src/main/scala/lucuma/itc/search/ObservingMode.scala
@@ -84,8 +84,7 @@ object ObservingMode {
       filter:            Option[GmosNorthFilter],
       ccdMode:           Option[GmosCcdMode],
       roi:               Option[GmosRoi]
-    ) extends GmosSpectroscopy
-        derives Hash {
+    ) extends GmosSpectroscopy derives Hash {
       val isIfu = fpu.isIfu
 
       val instrument: Instrument =
@@ -116,8 +115,7 @@ object ObservingMode {
       filter:            Option[GmosSouthFilter],
       ccdMode:           Option[GmosCcdMode],
       roi:               Option[GmosRoi]
-    ) extends GmosSpectroscopy
-        derives Hash {
+    ) extends GmosSpectroscopy derives Hash {
       val isIfu = fpu.isIfu
 
       val instrument: Instrument =

--- a/modules/service/src/main/scala/lucuma/itc/search/ObservingMode.scala
+++ b/modules/service/src/main/scala/lucuma/itc/search/ObservingMode.scala
@@ -143,9 +143,7 @@ object ObservingMode {
 
   }
 
-  sealed trait ImagingMode extends ObservingMode derives Hash {
-    // def λ: Wavelength
-  }
+  sealed trait ImagingMode extends ObservingMode derives Hash
 
   object ImagingMode {
     given Encoder[ObservingMode.ImagingMode] = Encoder.instance {
@@ -162,10 +160,10 @@ object ObservingMode {
     }
 
     case class GmosNorth(
-      // λ:       Wavelength,
       filter:  GmosNorthFilter,
       ccdMode: Option[GmosCcdMode]
     ) extends GmosImaging {
+      val centralWavelength: Wavelength = Wavelength.Min // Ignored for imaging
 
       val instrument: Instrument =
         Instrument.GmosNorth
@@ -177,14 +175,14 @@ object ObservingMode {
         Json.obj(
           ("instrument", Json.fromString(a.instrument.longName.toUpperCase.replace(" ", "_"))),
           ("params", GmosNImagingParams(a.filter).asJson)
-          // ("wavelength", a.λ.asJson)
         )
 
     case class GmosSouth(
-      // λ:       Wavelength,
       filter:  GmosSouthFilter,
       ccdMode: Option[GmosCcdMode]
     ) extends GmosImaging {
+      val centralWavelength: Wavelength = Wavelength.Min // Ignored for imaging
+
       val instrument: Instrument =
         Instrument.GmosSouth
     }
@@ -194,7 +192,6 @@ object ObservingMode {
         Json.obj(
           ("instrument", Json.fromString(a.instrument.longName.toUpperCase.replace(" ", "_"))),
           ("params", GmosSImagingParams(a.filter).asJson)
-          // ("wavelength", a.λ.asJson)
         )
   }
 

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -75,16 +75,16 @@ trait ItcCacheOrRemote extends Version:
   private def requestGraph[F[_]: Functor](itc: Itc[F])(
     request: TargetGraphRequest
   ): F[(TargetGraphsCalcResult, Band)] =
-    val band: Band = request.target.bandFor(request.wavelength)
+    val band: Band = request.target.bandFor(request.atWavelength)
     itc
       .calculateGraph(
         request.target,
+        request.atWavelength,
         band,
         request.specMode,
         request.constraints,
         request.expTime,
         request.exp
-        // request.signalToNoiseAt
       )
       .map((_, band))
 
@@ -102,10 +102,11 @@ trait ItcCacheOrRemote extends Version:
   private def requestSpecTimeCalc[F[_]: Functor](itc: Itc[F])(
     calcRequest: TargetSpectroscopyTimeRequest
   ): F[(NonEmptyChain[IntegrationTime], Band)] =
-    val band: Band = calcRequest.target.bandFor(calcRequest.wavelength)
+    val band: Band = calcRequest.target.bandFor(calcRequest.atWavelength)
     itc
       .calculateIntegrationTime(
         calcRequest.target,
+        calcRequest.atWavelength,
         band,
         calcRequest.specMode,
         calcRequest.constraints,
@@ -131,10 +132,11 @@ trait ItcCacheOrRemote extends Version:
   private def requestImgTimeCalc[F[_]: Functor](itc: Itc[F])(
     calcRequest: TargetImagingTimeRequest
   ): F[(NonEmptyChain[IntegrationTime], Band)] =
-    val band: Band = calcRequest.target.bandFor(calcRequest.wavelength)
+    val band: Band = calcRequest.target.bandFor(calcRequest.atWavelength)
     itc
       .calculateIntegrationTime(
         calcRequest.target,
+        calcRequest.atWavelength,
         band,
         calcRequest.imagingMode,
         calcRequest.constraints,

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -111,7 +111,6 @@ trait ItcCacheOrRemote extends Version:
         calcRequest.specMode,
         calcRequest.constraints,
         calcRequest.signalToNoise
-        // calcRequest.signalToNoiseAt
       )
       .map((_, band))
 

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -83,8 +83,8 @@ trait ItcCacheOrRemote extends Version:
         request.specMode,
         request.constraints,
         request.expTime,
-        request.exp,
-        request.signalToNoiseAt
+        request.exp
+        // request.signalToNoiseAt
       )
       .map((_, band))
 
@@ -104,13 +104,13 @@ trait ItcCacheOrRemote extends Version:
   ): F[(NonEmptyChain[IntegrationTime], Band)] =
     val band: Band = calcRequest.target.bandFor(calcRequest.wavelength)
     itc
-      .calculateIntegrationTime(
+      .calculateExposureTime(
         calcRequest.target,
         band,
         calcRequest.specMode,
         calcRequest.constraints,
-        calcRequest.signalToNoise,
-        calcRequest.signalToNoiseAt
+        calcRequest.signalToNoise
+        // calcRequest.signalToNoiseAt
       )
       .map((_, band))
 
@@ -133,13 +133,12 @@ trait ItcCacheOrRemote extends Version:
   ): F[(NonEmptyChain[IntegrationTime], Band)] =
     val band: Band = calcRequest.target.bandFor(calcRequest.wavelength)
     itc
-      .calculateIntegrationTime(
+      .calculateExposureTime(
         calcRequest.target,
         band,
         calcRequest.imagingMode,
         calcRequest.constraints,
-        calcRequest.signalToNoise,
-        none
+        calcRequest.signalToNoise
       )
       .map((_, band))
 

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -83,8 +83,7 @@ trait ItcCacheOrRemote extends Version:
         request.specMode,
         request.constraints,
         request.expTime,
-        request.exp,
-        request.wavelength
+        request.exp
         // request.signalToNoiseAt
       )
       .map((_, band))
@@ -110,8 +109,7 @@ trait ItcCacheOrRemote extends Version:
         band,
         calcRequest.specMode,
         calcRequest.constraints,
-        calcRequest.signalToNoise,
-        calcRequest.wavelength
+        calcRequest.signalToNoise
         // calcRequest.signalToNoiseAt
       )
       .map((_, band))
@@ -140,8 +138,7 @@ trait ItcCacheOrRemote extends Version:
         band,
         calcRequest.imagingMode,
         calcRequest.constraints,
-        calcRequest.signalToNoise,
-        calcRequest.wavelength
+        calcRequest.signalToNoise
       )
       .map((_, band))
 

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -104,7 +104,7 @@ trait ItcCacheOrRemote extends Version:
   ): F[(NonEmptyChain[IntegrationTime], Band)] =
     val band: Band = calcRequest.target.bandFor(calcRequest.wavelength)
     itc
-      .calculateExposureTime(
+      .calculateIntegrationTime(
         calcRequest.target,
         band,
         calcRequest.specMode,
@@ -133,7 +133,7 @@ trait ItcCacheOrRemote extends Version:
   ): F[(NonEmptyChain[IntegrationTime], Band)] =
     val band: Band = calcRequest.target.bandFor(calcRequest.wavelength)
     itc
-      .calculateExposureTime(
+      .calculateIntegrationTime(
         calcRequest.target,
         band,
         calcRequest.imagingMode,

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -83,7 +83,8 @@ trait ItcCacheOrRemote extends Version:
         request.specMode,
         request.constraints,
         request.expTime,
-        request.exp
+        request.exp,
+        request.wavelength
         // request.signalToNoiseAt
       )
       .map((_, band))
@@ -109,7 +110,8 @@ trait ItcCacheOrRemote extends Version:
         band,
         calcRequest.specMode,
         calcRequest.constraints,
-        calcRequest.signalToNoise
+        calcRequest.signalToNoise,
+        calcRequest.wavelength
         // calcRequest.signalToNoiseAt
       )
       .map((_, band))
@@ -138,7 +140,8 @@ trait ItcCacheOrRemote extends Version:
         band,
         calcRequest.imagingMode,
         calcRequest.constraints,
-        calcRequest.signalToNoise
+        calcRequest.signalToNoise,
+        calcRequest.wavelength
       )
       .map((_, band))
 

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcMappings.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcMappings.scala
@@ -213,8 +213,7 @@ object ItcMapping extends ItcCacheOrRemote with Version {
         asterismRequest.specMode,
         asterismRequest.constraints,
         expTime,
-        expCount,
-        asterismRequest.signalToNoiseAt
+        expCount
       ),
       figures
     )

--- a/modules/service/src/main/scala/lucuma/itc/service/ItcMappings.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/ItcMappings.scala
@@ -121,8 +121,8 @@ object ItcMapping extends ItcCacheOrRemote with Version {
                 .bimap(buildError, buildTargetIntegrationTime)
                 .map: (integrationTime: TargetIntegrationTime) =>
                   asterismRequest.imagingMode match
-                    case ObservingMode.ImagingMode.GmosNorth(_, _, _) |
-                        ObservingMode.ImagingMode.GmosSouth(_, _, _) =>
+                    case ObservingMode.ImagingMode.GmosNorth(_, _) |
+                        ObservingMode.ImagingMode.GmosSouth(_, _) =>
                       integrationTime
                         .focusIndex(1) // For gmos focus on the second CCD
                         .getOrElse(integrationTime)
@@ -209,7 +209,7 @@ object ItcMapping extends ItcCacheOrRemote with Version {
     AsterismGraphRequest(
       asterismRequest.asterism,
       GraphParameters(
-        asterismRequest.wavelength,
+        asterismRequest.atWavelength,
         asterismRequest.specMode,
         asterismRequest.constraints,
         expTime,

--- a/modules/service/src/main/scala/lucuma/itc/service/requests/graph.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/requests/graph.scala
@@ -24,12 +24,12 @@ import lucuma.itc.search.TargetData
 import lucuma.itc.search.hashes.given
 
 case class GraphParameters(
-  wavelength:      Wavelength,
-  specMode:        ObservingMode.SpectroscopyMode,
-  constraints:     ItcObservingConditions,
-  expTime:         TimeSpan,
-  exp:             PosInt,
-  signalToNoiseAt: Option[Wavelength]
+  wavelength:  Wavelength,
+  specMode:    ObservingMode.SpectroscopyMode,
+  constraints: ItcObservingConditions,
+  expTime:     TimeSpan,
+  exp:         PosInt
+  // signalToNoiseAt: Option[Wavelength]
 ) derives Hash
 
 case class TargetGraphRequest(
@@ -53,7 +53,6 @@ object AsterismGraphRequest:
   def fromInput(input: SpectroscopyGraphsInput): Result[AsterismGraphRequest] = {
     val SpectroscopyGraphsInput(
       wavelength,
-      signalToNoiseAt,
       exposureTime,
       exposureCount,
       asterism,
@@ -92,8 +91,7 @@ object AsterismGraphRequest:
           mode,
           conditions,
           exposureTime,
-          exposureCount,
-          signalToNoiseAt
+          exposureCount
         ),
         figures
       )

--- a/modules/service/src/main/scala/lucuma/itc/service/requests/graph.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/requests/graph.scala
@@ -24,12 +24,11 @@ import lucuma.itc.search.TargetData
 import lucuma.itc.search.hashes.given
 
 case class GraphParameters(
-  wavelength:  Wavelength,
-  specMode:    ObservingMode.SpectroscopyMode,
-  constraints: ItcObservingConditions,
-  expTime:     TimeSpan,
-  exp:         PosInt
-  // signalToNoiseAt: Option[Wavelength]
+  atWavelength: Wavelength,
+  specMode:     ObservingMode.SpectroscopyMode,
+  constraints:  ItcObservingConditions,
+  expTime:      TimeSpan,
+  exp:          PosInt
 ) derives Hash
 
 case class TargetGraphRequest(
@@ -52,7 +51,7 @@ case class AsterismGraphRequest(
 object AsterismGraphRequest:
   def fromInput(input: SpectroscopyGraphsInput): Result[AsterismGraphRequest] = {
     val SpectroscopyGraphsInput(
-      wavelength,
+      atWavelength,
       exposureTime,
       exposureCount,
       asterism,
@@ -65,17 +64,31 @@ object AsterismGraphRequest:
       targetInputsToData(asterism)
 
     val modeResult: Result[ObservingMode.SpectroscopyMode] = mode match {
-      case GmosNSpectroscopyInput(grating, GmosFpuMask.Builtin(fpu), filter, ccdMode, roi) =>
+      case GmosNSpectroscopyInput(
+            centralWavelength,
+            grating,
+            GmosFpuMask.Builtin(fpu),
+            filter,
+            ccdMode,
+            roi
+          ) =>
         Result(
           ObservingMode.SpectroscopyMode
-            .GmosNorth(wavelength, grating, GmosNorthFpuParam(fpu), filter, ccdMode, roi)
+            .GmosNorth(centralWavelength, grating, GmosNorthFpuParam(fpu), filter, ccdMode, roi)
         )
-      case GmosSSpectroscopyInput(grating, GmosFpuMask.Builtin(fpu), filter, ccdMode, roi) =>
+      case GmosSSpectroscopyInput(
+            centralWavelength,
+            grating,
+            GmosFpuMask.Builtin(fpu),
+            filter,
+            ccdMode,
+            roi
+          ) =>
         Result(
           ObservingMode.SpectroscopyMode
-            .GmosSouth(wavelength, grating, GmosSouthFpuParam(fpu), filter, ccdMode, roi)
+            .GmosSouth(centralWavelength, grating, GmosSouthFpuParam(fpu), filter, ccdMode, roi)
         )
-      case _                                                                               =>
+      case _ =>
         Result.failure("Invalid spectroscopy mode")
     }
 
@@ -87,7 +100,7 @@ object AsterismGraphRequest:
       AsterismGraphRequest(
         asterism,
         GraphParameters(
-          wavelength,
+          atWavelength,
           mode,
           conditions,
           exposureTime,

--- a/modules/service/src/main/scala/lucuma/itc/service/requests/imagingTime.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/requests/imagingTime.scala
@@ -18,7 +18,7 @@ import lucuma.itc.search.TargetData
 import lucuma.itc.search.hashes.given
 
 case class ImagingTimeParameters(
-  wavelength:    Wavelength,
+  atWavelength:  Wavelength,
   imagingMode:   ObservingMode.ImagingMode,
   constraints:   ItcObservingConditions,
   signalToNoise: SignalToNoise
@@ -43,7 +43,7 @@ case class AsterismImagingTimeRequest(
 object AsterismImagingTimeRequest:
   def fromInput(input: ImagingIntegrationTimeInput): Result[AsterismImagingTimeRequest] = {
     val ImagingIntegrationTimeInput(
-      wavelength,
+      atWavelength,
       signalToNoise,
       asterism,
       constraints,
@@ -57,10 +57,10 @@ object AsterismImagingTimeRequest:
       mode match
         case GmosNImagingInput(filter, ccdMode) =>
           Result.success:
-            ObservingMode.ImagingMode.GmosNorth(wavelength, filter, ccdMode)
+            ObservingMode.ImagingMode.GmosNorth(filter, ccdMode)
         case GmosSImagingInput(filter, ccdMode) =>
           Result.success:
-            ObservingMode.ImagingMode.GmosSouth(wavelength, filter, ccdMode)
+            ObservingMode.ImagingMode.GmosSouth(filter, ccdMode)
         case _                                  =>
           Result.failure("Invalid imaging mode")
 
@@ -71,6 +71,6 @@ object AsterismImagingTimeRequest:
     (asterismResult, modeResult, conditionsResult).parMapN: (asterism, mode, conditions) =>
       AsterismImagingTimeRequest(
         asterism,
-        ImagingTimeParameters(wavelength, mode, conditions, signalToNoise)
+        ImagingTimeParameters(atWavelength, mode, conditions, signalToNoise)
       )
   }

--- a/modules/service/src/main/scala/lucuma/itc/service/requests/spectroscopyTime.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/requests/spectroscopyTime.scala
@@ -21,11 +21,11 @@ import lucuma.itc.search.TargetData
 import lucuma.itc.search.hashes.given
 
 case class SpectroscopyTimeParameters(
-  wavelength:      Wavelength,
-  specMode:        ObservingMode.SpectroscopyMode,
-  constraints:     ItcObservingConditions,
-  signalToNoise:   SignalToNoise,
-  signalToNoiseAt: Option[Wavelength]
+  wavelength:    Wavelength,
+  specMode:      ObservingMode.SpectroscopyMode,
+  constraints:   ItcObservingConditions,
+  signalToNoise: SignalToNoise
+  // signalToNoiseAt: Option[Wavelength]
 ) derives Hash
 
 case class TargetSpectroscopyTimeRequest(
@@ -46,14 +46,7 @@ case class AsterismSpectroscopyTimeRequest(
 
 object AsterismSpectroscopyTimeRequest:
   def fromInput(input: SpectroscopyTimeInput): Result[AsterismSpectroscopyTimeRequest] = {
-    val SpectroscopyTimeInput(
-      wavelength,
-      signalToNoise,
-      signalToNoiseAt,
-      asterism,
-      constraints,
-      mode
-    ) =
+    val SpectroscopyTimeInput(wavelength, signalToNoise, asterism, constraints, mode) =
       input
 
     val asterismResult: Result[NonEmptyChain[TargetData]] =
@@ -79,6 +72,6 @@ object AsterismSpectroscopyTimeRequest:
     (asterismResult, modeResult, conditionsResult).parMapN: (asterism, mode, conditions) =>
       AsterismSpectroscopyTimeRequest(
         asterism,
-        SpectroscopyTimeParameters(wavelength, mode, conditions, signalToNoise, signalToNoiseAt)
+        SpectroscopyTimeParameters(wavelength, mode, conditions, signalToNoise)
       )
   }

--- a/modules/service/src/main/scala/lucuma/itc/service/requests/spectroscopyTime.scala
+++ b/modules/service/src/main/scala/lucuma/itc/service/requests/spectroscopyTime.scala
@@ -21,11 +21,10 @@ import lucuma.itc.search.TargetData
 import lucuma.itc.search.hashes.given
 
 case class SpectroscopyTimeParameters(
-  wavelength:    Wavelength,
+  atWavelength:  Wavelength,
   specMode:      ObservingMode.SpectroscopyMode,
   constraints:   ItcObservingConditions,
   signalToNoise: SignalToNoise
-  // signalToNoiseAt: Option[Wavelength]
 ) derives Hash
 
 case class TargetSpectroscopyTimeRequest(
@@ -54,15 +53,29 @@ object AsterismSpectroscopyTimeRequest:
 
     val modeResult: Result[ObservingMode.SpectroscopyMode] =
       mode match
-        case GmosNSpectroscopyInput(grating, GmosFpuMask.Builtin(fpu), filter, ccdMode, roi) =>
+        case GmosNSpectroscopyInput(
+              centralWavelength,
+              grating,
+              GmosFpuMask.Builtin(fpu),
+              filter,
+              ccdMode,
+              roi
+            ) =>
           Result.success:
             ObservingMode.SpectroscopyMode
-              .GmosNorth(wavelength, grating, GmosNorthFpuParam(fpu), filter, ccdMode, roi)
-        case GmosSSpectroscopyInput(grating, GmosFpuMask.Builtin(fpu), filter, ccdMode, roi) =>
+              .GmosNorth(centralWavelength, grating, GmosNorthFpuParam(fpu), filter, ccdMode, roi)
+        case GmosSSpectroscopyInput(
+              centralWavelength,
+              grating,
+              GmosFpuMask.Builtin(fpu),
+              filter,
+              ccdMode,
+              roi
+            ) =>
           Result.success:
             ObservingMode.SpectroscopyMode
-              .GmosSouth(wavelength, grating, GmosSouthFpuParam(fpu), filter, ccdMode, roi)
-        case _                                                                               =>
+              .GmosSouth(centralWavelength, grating, GmosSouthFpuParam(fpu), filter, ccdMode, roi)
+        case _ =>
           Result.failure("Invalid spectroscopy mode")
 
     val conditionsResult: Result[ItcObservingConditions] =

--- a/modules/testkit/src/main/scala/lucuma/itc/client/arb/ArbInstrumentMode.scala
+++ b/modules/testkit/src/main/scala/lucuma/itc/client/arb/ArbInstrumentMode.scala
@@ -9,6 +9,8 @@ import lucuma.core.enums.GmosNorthGrating
 import lucuma.core.enums.GmosRoi
 import lucuma.core.enums.GmosSouthFilter
 import lucuma.core.enums.GmosSouthGrating
+import lucuma.core.math.Wavelength
+import lucuma.core.math.arb.ArbWavelength
 import lucuma.core.model.sequence.gmos.GmosCcdMode
 import lucuma.core.model.sequence.gmos.arb.ArbGmosCcdMode
 import lucuma.core.util.arb.ArbEnumerated
@@ -16,10 +18,10 @@ import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 
 trait ArbInstrumentMode {
-
   import ArbEnumerated.given
   import ArbGmosFpu.given
   import ArbGmosCcdMode.given
+  import ArbWavelength.given
 
   import InstrumentMode.GmosNorthSpectroscopy
   import InstrumentMode.GmosSouthSpectroscopy
@@ -29,23 +31,26 @@ trait ArbInstrumentMode {
   given Arbitrary[GmosNorthSpectroscopy] =
     Arbitrary {
       for {
-        g <- arbitrary[GmosNorthGrating]
-        f <- arbitrary[Option[GmosNorthFilter]]
-        u <- arbitrary[GmosFpu.North]
-        c <- arbitrary[Option[GmosCcdMode]]
-        r <- arbitrary[Option[GmosRoi]]
-      } yield GmosNorthSpectroscopy(g, f, u, c, r)
+        cw <- arbitrary[Wavelength]
+        g  <- arbitrary[GmosNorthGrating]
+        f  <- arbitrary[Option[GmosNorthFilter]]
+        u  <- arbitrary[GmosFpu.North]
+        c  <- arbitrary[Option[GmosCcdMode]]
+        r  <- arbitrary[Option[GmosRoi]]
+      } yield GmosNorthSpectroscopy(cw, g, f, u, c, r)
     }
 
   given Cogen[GmosNorthSpectroscopy] =
     Cogen[
       (
+        Wavelength,
         GmosNorthGrating,
         Option[GmosNorthFilter],
         GmosFpu.North
       )
     ].contramap { a =>
       (
+        a.centralWavelength,
         a.grating,
         a.filter,
         a.fpu
@@ -55,23 +60,26 @@ trait ArbInstrumentMode {
   given Arbitrary[GmosSouthSpectroscopy] =
     Arbitrary {
       for {
-        g <- arbitrary[GmosSouthGrating]
-        f <- arbitrary[Option[GmosSouthFilter]]
-        u <- arbitrary[GmosFpu.South]
-        c <- arbitrary[Option[GmosCcdMode]]
-        r <- arbitrary[Option[GmosRoi]]
-      } yield GmosSouthSpectroscopy(g, f, u, c, r)
+        cw <- arbitrary[Wavelength]
+        g  <- arbitrary[GmosSouthGrating]
+        f  <- arbitrary[Option[GmosSouthFilter]]
+        u  <- arbitrary[GmosFpu.South]
+        c  <- arbitrary[Option[GmosCcdMode]]
+        r  <- arbitrary[Option[GmosRoi]]
+      } yield GmosSouthSpectroscopy(cw, g, f, u, c, r)
     }
 
   given Cogen[GmosSouthSpectroscopy] =
     Cogen[
       (
+        Wavelength,
         GmosSouthGrating,
         Option[GmosSouthFilter],
         GmosFpu.South
       )
     ].contramap { a =>
       (
+        a.centralWavelength,
         a.grating,
         a.filter,
         a.fpu
@@ -82,21 +90,23 @@ trait ArbInstrumentMode {
     Arbitrary {
       for {
         f <- arbitrary[GmosNorthFilter]
-      } yield GmosNorthImaging(f)
+        c <- arbitrary[Option[GmosCcdMode]]
+      } yield GmosNorthImaging(f, c)
     }
 
   given Cogen[GmosNorthImaging] =
-    Cogen[GmosNorthFilter].contramap(_.filter)
+    Cogen[(GmosNorthFilter, Option[GmosCcdMode])].contramap(a => (a.filter, a.ccdMode))
 
   given Arbitrary[GmosSouthImaging] =
     Arbitrary {
       for {
         f <- arbitrary[GmosSouthFilter]
-      } yield GmosSouthImaging(f)
+        c <- arbitrary[Option[GmosCcdMode]]
+      } yield GmosSouthImaging(f, c)
     }
 
   given Cogen[GmosSouthImaging] =
-    Cogen[GmosSouthFilter].contramap(_.filter)
+    Cogen[(GmosSouthFilter, Option[GmosCcdMode])].contramap(a => (a.filter, a.ccdMode))
 
   given Arbitrary[InstrumentMode] =
     Arbitrary {

--- a/modules/testkit/src/main/scala/lucuma/itc/client/arb/ArbIntegrationTimeInput.scala
+++ b/modules/testkit/src/main/scala/lucuma/itc/client/arb/ArbIntegrationTimeInput.scala
@@ -30,10 +30,9 @@ trait ArbIntegrationTimeInput {
       for
         w   <- arbitrary[Wavelength]
         s2n <- arbitrary[SignalToNoise]
-        sat <- arbitrary[Option[Wavelength]]
         cs  <- arbitrary[ConstraintSet]
         im  <- arbitrary[InstrumentMode]
-      yield SpectroscopyIntegrationTimeParameters(w, s2n, sat, cs, im)
+      yield SpectroscopyIntegrationTimeParameters(w, s2n, cs, im)
 
   given Arbitrary[SpectroscopyIntegrationTimeInput] =
     Arbitrary:
@@ -44,15 +43,9 @@ trait ArbIntegrationTimeInput {
 
   given Cogen[SpectroscopyIntegrationTimeInput] =
     Cogen[
-      (Wavelength,
-       SignalToNoise,
-       Option[Wavelength],
-       List[TargetInput],
-       ConstraintSet,
-       InstrumentMode
-      )
+      (Wavelength, SignalToNoise, List[TargetInput], ConstraintSet, InstrumentMode)
     ].contramap: a =>
-      (a.wavelength, a.signalToNoise, a.signalToNoiseAt, a.asterism.toList, a.constraints, a.mode)
+      (a.wavelength, a.signalToNoise, a.asterism.toList, a.constraints, a.mode)
 
   given Arbitrary[ImagingIntegrationTimeParameters] =
     Arbitrary:

--- a/modules/testkit/src/main/scala/lucuma/itc/client/arb/ArbIntegrationTimeInput.scala
+++ b/modules/testkit/src/main/scala/lucuma/itc/client/arb/ArbIntegrationTimeInput.scala
@@ -45,7 +45,7 @@ trait ArbIntegrationTimeInput {
     Cogen[
       (Wavelength, SignalToNoise, List[TargetInput], ConstraintSet, InstrumentMode)
     ].contramap: a =>
-      (a.wavelength, a.signalToNoise, a.asterism.toList, a.constraints, a.mode)
+      (a.atWavelength, a.signalToNoise, a.asterism.toList, a.constraints, a.mode)
 
   given Arbitrary[ImagingIntegrationTimeParameters] =
     Arbitrary:
@@ -73,7 +73,7 @@ trait ArbIntegrationTimeInput {
         InstrumentMode
       )
     ].contramap: a =>
-      (a.wavelength, a.signalToNoise, a.asterism.toList, a.constraints, a.mode)
+      (a.atWavelength, a.signalToNoise, a.asterism.toList, a.constraints, a.mode)
 }
 
 object ArbIntegrationTimeInput extends ArbIntegrationTimeInput

--- a/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
@@ -9,7 +9,6 @@ import cats.data.NonEmptyList
 import cats.syntax.either.*
 import cats.syntax.option.*
 import eu.timepit.refined.types.numeric.PosInt
-import io.circe.syntax.*
 import lucuma.core.data.Zipper
 import lucuma.core.enums.Band
 import lucuma.core.enums.CloudExtinction
@@ -53,7 +52,6 @@ import lucuma.itc.SeriesDataType
 import lucuma.itc.SingleSN
 import lucuma.itc.TargetIntegrationTime
 import lucuma.itc.TargetIntegrationTimeOutcome
-import lucuma.itc.client.json.encoders.given
 import lucuma.itc.service.ItcMapping.versionDateTimeFormatter
 import lucuma.refined.*
 
@@ -105,22 +103,22 @@ class WiringSuite extends ClientSuite {
     )
   }
 
-  test("SignalToNoiseAt null is removed") {
-    WiringSuite.SpectroscopyInput.asJson.asObject
-      .exists(!_.contains("signalToNoiseAt"))
-  }
+  // test("SignalToNoiseAt null is removed") {
+  //   WiringSuite.SpectroscopyInput.asJson.asObject
+  //     .exists(!_.contains("signalToNoiseAt"))
+  // }
 
-  test("SignalToNoiseAt non-null is included") {
-    WiringSuite.SpectroscopyInput
-      .copy(parameters =
-        WiringSuite.SpectroscopyInput.parameters.copy(signalToNoiseAt = Wavelength.Min.some)
-      )
-      .asJson
-      .asObject
-      .flatMap(_.apply("signalToNoiseAt"))
-      .map(_.spaces2)
-      .contains(Wavelength.Min.asJson)
-  }
+  // test("SignalToNoiseAt non-null is included") {
+  //   WiringSuite.SpectroscopyInput
+  //     .copy(parameters =
+  //       WiringSuite.SpectroscopyInput.parameters.copy(signalToNoiseAt = Wavelength.Min.some)
+  //     )
+  //     .asJson
+  //     .asObject
+  //     .flatMap(_.apply("signalToNoiseAt"))
+  //     .map(_.spaces2)
+  //     .contains(Wavelength.Min.asJson)
+  // }
 
   test("ItcClient spectroscopy graph wiring and sanity check") {
     spectroscopyGraphs(
@@ -182,7 +180,6 @@ object WiringSuite {
       SpectroscopyIntegrationTimeParameters(
         Wavelength.Min,
         SignalToNoise.unsafeFromBigDecimalExact(BigDecimal(1)),
-        Option.empty[Wavelength],
         ConstraintSet(
           ImageQuality.PointOne,
           CloudExtinction.PointOne,
@@ -262,7 +259,6 @@ object WiringSuite {
     SpectroscopyGraphsInput(
       SpectroscopyGraphParameters(
         Wavelength.Min,
-        Wavelength.fromIntMicrometers(1),
         TimeSpan.fromSeconds(1).get,
         PosInt.unsafeFrom(5),
         ConstraintSet(

--- a/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
@@ -188,6 +188,7 @@ object WiringSuite {
           AirMass.Default
         ),
         InstrumentMode.GmosNorthSpectroscopy(
+          Wavelength.Min,
           GmosNorthGrating.B1200_G5301,
           GmosNorthFilter.GPrime.some,
           GmosFpu.North.builtin(GmosNorthFpu.LongSlit_0_25),
@@ -233,7 +234,8 @@ object WiringSuite {
           AirMass.Default
         ),
         InstrumentMode.GmosNorthImaging(
-          GmosNorthFilter.GPrime
+          GmosNorthFilter.GPrime,
+          none
         )
       ),
       NonEmptyList.of(
@@ -269,6 +271,7 @@ object WiringSuite {
           AirMass.Default
         ),
         InstrumentMode.GmosNorthSpectroscopy(
+          Wavelength.Min,
           GmosNorthGrating.B1200_G5301,
           GmosNorthFilter.GPrime.some,
           GmosFpu.North.builtin(GmosNorthFpu.LongSlit_0_25),

--- a/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
@@ -103,23 +103,6 @@ class WiringSuite extends ClientSuite {
     )
   }
 
-  // test("SignalToNoiseAt null is removed") {
-  //   WiringSuite.SpectroscopyInput.asJson.asObject
-  //     .exists(!_.contains("signalToNoiseAt"))
-  // }
-
-  // test("SignalToNoiseAt non-null is included") {
-  //   WiringSuite.SpectroscopyInput
-  //     .copy(parameters =
-  //       WiringSuite.SpectroscopyInput.parameters.copy(signalToNoiseAt = Wavelength.Min.some)
-  //     )
-  //     .asJson
-  //     .asObject
-  //     .flatMap(_.apply("signalToNoiseAt"))
-  //     .map(_.spaces2)
-  //     .contains(Wavelength.Min.asJson)
-  // }
-
   test("ItcClient spectroscopy graph wiring and sanity check") {
     spectroscopyGraphs(
       WiringSuite.GraphInput,

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLImagingTimeSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLImagingTimeSuite.scala
@@ -12,7 +12,7 @@ class GraphQLImagingTimeSuite extends GraphImagingQLSuite {
       """
         query {
           imagingIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               picometers: 530000
             },
             signalToNoise: 600,
@@ -96,9 +96,6 @@ class GraphQLImagingTimeSuite extends GraphImagingQLSuite {
                     filter
                   }
                 }
-                wavelength {
-                  nanometers
-                }
               }
             }
             brightest {
@@ -129,9 +126,6 @@ class GraphQLImagingTimeSuite extends GraphImagingQLSuite {
                 "instrument" : "GMOS_NORTH",
                 "params": {
                   "filter": "G_PRIME"
-                },
-                "wavelength" : {
-                  "nanometers" : 530.000
                 }
               },
               "brightest" : {

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLIntTimeErrorsSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLIntTimeErrorsSuite.scala
@@ -13,7 +13,7 @@ class GraphQLIntTimeErrorsSuite extends FailingCalculationSuite {
         query {
           spectroscopyIntegrationTime(input: {
             atWavelength: {
-              nanometers: 60,
+              nanometers: 60
             },
             signalToNoise: 2,
             asterism: [

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLIntTimeErrorsSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLIntTimeErrorsSuite.scala
@@ -12,7 +12,7 @@ class GraphQLIntTimeErrorsSuite extends FailingCalculationSuite {
       """
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -55,6 +55,9 @@ class GraphQLIntTimeErrorsSuite extends FailingCalculationSuite {
             },
             mode: {
               gmosNSpectroscopy: {
+                centralWavelength: {
+                  nanometers: 60
+                },
                 filter: GG455,
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -72,7 +75,7 @@ class GraphQLIntTimeErrorsSuite extends FailingCalculationSuite {
                     grating
                   }
                 }
-                wavelength {
+                centralWavelength {
                   nanometers
                 }
               }
@@ -109,7 +112,7 @@ class GraphQLIntTimeErrorsSuite extends FailingCalculationSuite {
                 "params" : {
                   "grating" : "B1200_G5301"
                 },
-                "wavelength" : {
+                "centralWavelength" : {
                   "nanometers" : 60.000
                 }
               },

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyGraphSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyGraphSuite.scala
@@ -12,7 +12,7 @@ class GraphQLSpectroscopyGraphSuite extends GraphQLSuite {
       """
         query {
           spectroscopyGraphs(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             exposureTime: {
@@ -58,6 +58,9 @@ class GraphQLSpectroscopyGraphSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
+                centralWavelength: {
+                  nanometers: 60
+                },
                 filter: G_PRIME,
                 fpu: {
                   builtin: LONG_SLIT_0_25

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyTimeAndGraphSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyTimeAndGraphSuite.scala
@@ -16,9 +16,6 @@ class GraphQLSpectroscopyTimeAndGraphSuite extends GraphQLSuite {
               nanometers: 60,
             },
             signalToNoise: 2,
-            signalToNoiseAt: {
-              nanometers: 60,
-            },
             asterism: [
               {
                 sourceProfile: {

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyTimeAndGraphSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyTimeAndGraphSuite.scala
@@ -12,7 +12,7 @@ class GraphQLSpectroscopyTimeAndGraphSuite extends GraphQLSuite {
       """
         query {
           spectroscopyIntegrationTimeAndGraphs(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -55,6 +55,9 @@ class GraphQLSpectroscopyTimeAndGraphSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
+                centralWavelength: {
+                  nanometers: 60
+                },
                 filter: G_PRIME,
                 fpu: {
                   builtin: LONG_SLIT_0_25

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyTimeSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyTimeSuite.scala
@@ -60,7 +60,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
-                centralWavelength {
+                centralWavelength: {
                   nanometers: 60
                 },
                 filter: GG455,
@@ -176,7 +176,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosSSpectroscopy: {
-                centralWavelength {
+                centralWavelength: {
                   nanometers: 60
                 },
                 filter: RG610,
@@ -196,7 +196,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                       grating
                     }
                   }
-                  wavelength {
+                  centralWavelength {
                     nanometers
                   }
                 }
@@ -385,7 +385,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
-                centralWavelength {
+                centralWavelength: {
                   nanometers: 60
                 },
                 filter: G_PRIME,
@@ -405,7 +405,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                         grating
                       }
                     }
-                    wavelength {
+                    centralWavelength {
                       nanometers
                     }
                   }
@@ -500,7 +500,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
-                centralWavelength {
+                centralWavelength: {
                   nanometers: 60
                 },
                 filter: G_PRIME,
@@ -598,7 +598,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
-                centralWavelength {
+                centralWavelength: {
                   nanometers: 60
                 },
                 filter: G_PRIME,
@@ -717,7 +717,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosSSpectroscopy: {
-                centralWavelength {
+                centralWavelength: {
                   nanometers: 60
                 },
                 filter: G_PRIME,
@@ -836,7 +836,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
               },
               mode: {
                 gmosNSpectroscopy: {
-                  centralWavelength {
+                  centralWavelength: {
                     nanometers: 60,
                   },
                   filter: G_PRIME,
@@ -954,7 +954,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosSSpectroscopy: {
-                centralWavelength {
+                centralWavelength: {
                   nanometers: 60,
                 },
                 filter: G_PRIME,
@@ -1072,7 +1072,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
-                centralWavelength {
+                centralWavelength: {
                   nanometers: 60,
                 },
                 filter: ${d.tag.toScreamingSnakeCase}
@@ -1186,7 +1186,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosSSpectroscopy: {
-                centralWavelength {
+                centralWavelength: {
                   nanometers: 60,
                 },
                 filter: ${d.tag.toScreamingSnakeCase}

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyTimeSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLSpectroscopyTimeSuite.scala
@@ -17,7 +17,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
       """
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -60,6 +60,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
+                centralWavelength {
+                  nanometers: 60
+                },
                 filter: GG455,
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -77,7 +80,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                     grating
                   }
                 }
-                wavelength {
+                centralWavelength {
                   nanometers
                 }
               }
@@ -104,7 +107,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                 "params": {
                   "grating": "B1200_G5301"
                 },
-                "wavelength" : {
+                "centralWavelength" : {
                   "nanometers" : 60.000
                 }
               },
@@ -129,7 +132,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
       """
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -173,6 +176,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosSSpectroscopy: {
+                centralWavelength {
+                  nanometers: 60
+                },
                 filter: RG610,
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -216,7 +222,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                   "params": {
                     "grating": "B1200_G5321"
                   },
-                  "wavelength" : {
+                  "centralWavelength" : {
                     "nanometers" : 60.000
                   }
                 },
@@ -243,7 +249,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
       """
         {
           "spectroscopy" : {
-            "wavelength" : {
+            "atWavelength" : {
               "nanometers" : "600"
             },
             "signalToNoise" : 2,
@@ -286,6 +292,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             "mode": {
               "gmosNSpectroscopy": {
+                "centralWavelength": {
+                  "nanometers": "600"
+                },
                 "filter": "G_PRIME",
                 "fpu": {
                   "builtin": "LONG_SLIT_0_25"
@@ -333,7 +342,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
         s"""
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -376,6 +385,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
+                centralWavelength {
+                  nanometers: 60
+                },
                 filter: G_PRIME,
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -420,7 +432,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                   "params": {
                     "grating": "B1200_G5301"
                   },
-                  "wavelength" : {
+                  "centralWavelength" : {
                     "nanometers" : 60.000
                   }
                 },
@@ -445,7 +457,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
       """
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -488,6 +500,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
+                centralWavelength {
+                  nanometers: 60
+                },
                 filter: G_PRIME,
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -505,7 +520,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                       grating
                     }
                   }
-                  wavelength {
+                  centralWavelength {
                     nanometers
                   }
                 }
@@ -540,7 +555,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
         s"""
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -583,6 +598,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
+                centralWavelength {
+                  nanometers: 60
+                },
                 filter: G_PRIME,
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -599,7 +617,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                         grating
                       }
                     }
-                    wavelength {
+                    centralWavelength {
                       nanometers
                     }
                   }
@@ -625,7 +643,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                   "params": {
                     "grating": ${d.tag.toScreamingSnakeCase}
                   },
-                  "wavelength" : {
+                  "centralWavelength" : {
                     "nanometers" : 60.000
                   }
                 },
@@ -651,7 +669,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
         s"""
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -699,6 +717,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosSSpectroscopy: {
+                centralWavelength {
+                  nanometers: 60
+                },
                 filter: G_PRIME,
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -715,7 +736,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                         grating
                       }
                     }
-                    wavelength {
+                    centralWavelength {
                       nanometers
                     }
                   }
@@ -741,7 +762,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                   "params": {
                     "grating": ${d.tag.toScreamingSnakeCase}
                   },
-                  "wavelength" : {
+                  "centralWavelength" : {
                     "nanometers" : 60.00
                   }
                 },
@@ -767,7 +788,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
         s"""
           query {
             spectroscopyIntegrationTime(input: {
-              wavelength: {
+              atWavelength: {
                 nanometers: 60,
               },
               signalToNoise: 2,
@@ -815,6 +836,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
               },
               mode: {
                 gmosNSpectroscopy: {
+                  centralWavelength {
+                    nanometers: 60,
+                  },
                   filter: G_PRIME,
                   fpu: {
                     builtin: ${d.tag.toScreamingSnakeCase}
@@ -833,7 +857,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                           }
                         }
                       }
-                      wavelength {
+                      centralWavelength {
                         nanometers
                       }
                     }
@@ -861,7 +885,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                       "builtin": ${d.tag.toScreamingSnakeCase}
                     }
                   },
-                  "wavelength" : {
+                  "centralWavelength" : {
                     "nanometers" : 60.00
                   }
                 },
@@ -887,7 +911,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
         s"""
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -930,6 +954,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosSSpectroscopy: {
+                centralWavelength {
+                  nanometers: 60,
+                },
                 filter: G_PRIME,
                 fpu: {
                   builtin: ${d.tag.toScreamingSnakeCase}
@@ -948,7 +975,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                         }
                       }
                     }
-                    wavelength {
+                    centralWavelength {
                       nanometers
                     }
                   }
@@ -976,7 +1003,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                       "builtin": ${d.tag.toScreamingSnakeCase}
                     }
                   },
-                  "wavelength" : {
+                  "centralWavelength" : {
                     "nanometers" : 60.00
                   }
                 },
@@ -1002,7 +1029,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
         s"""
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -1045,6 +1072,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
+                centralWavelength {
+                  nanometers: 60,
+                },
                 filter: ${d.tag.toScreamingSnakeCase}
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -1061,7 +1091,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                         filter
                       }
                     }
-                    wavelength {
+                    centralWavelength {
                       nanometers
                     }
                   }
@@ -1087,7 +1117,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                   "params": {
                     "filter": ${d.tag.toScreamingSnakeCase}
                   },
-                  "wavelength" : {
+                  "centralWavelength" : {
                     "nanometers" : 60.000
                   }
                 },
@@ -1113,7 +1143,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
         s"""
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 60,
             },
             signalToNoise: 2,
@@ -1156,6 +1186,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosSSpectroscopy: {
+                centralWavelength {
+                  nanometers: 60,
+                },
                 filter: ${d.tag.toScreamingSnakeCase}
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -1172,7 +1205,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                         filter
                       }
                     }
-                    wavelength {
+                    centralWavelength {
                       nanometers
                     }
                   }
@@ -1198,7 +1231,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                   "params": {
                     "filter": ${d.tag.toScreamingSnakeCase}
                   },
-                  "wavelength" : {
+                  "centralWavelength" : {
                     "nanometers" : 60.000
                   }
                 },
@@ -1223,7 +1256,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
       """
         query {
           spectroscopyIntegrationTime(input: {
-            wavelength: {
+            atWavelength: {
               nanometers: 600,
             },
             signalToNoise: 2,
@@ -1285,6 +1318,9 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
             },
             mode: {
               gmosNSpectroscopy: {
+                centralWavelength: {
+                  nanometers: 600
+                },
                 filter: GG455,
                 fpu: {
                   builtin: LONG_SLIT_0_25
@@ -1302,7 +1338,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                     grating
                   }
                 }
-                wavelength {
+                centralWavelength {
                   nanometers
                 }
               }
@@ -1332,7 +1368,7 @@ class GraphQLSpectroscopyTimeSuite extends GraphQLSuite {
                 "params": {
                   "grating": "B1200_G5301"
                 },
-                "wavelength" : {
+                "centralWavelength" : {
                   "nanometers" : 600.000
                 }
               },

--- a/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
@@ -29,6 +29,7 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
   override def calculateIntegrationTime(
     target:        TargetData,
+    atWavelength:  Wavelength,
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
@@ -40,6 +41,7 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
   override def calculateGraph(
     target:        TargetData,
+    atWavelength:  Wavelength,
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
@@ -48,16 +50,17 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(
-        ItcCcd(1,
-               1,
-               2,
-               2,
-               Wavelength.fromIntNanometers(1001).get,
-               Wavelength.fromIntNanometers(1001).get,
-               3,
-               4,
-               5,
-               Nil
+        ItcCcd(
+          1,
+          1,
+          2,
+          2,
+          Wavelength.fromIntNanometers(1001).get,
+          Wavelength.fromIntNanometers(1001).get,
+          3,
+          4,
+          5,
+          Nil
         )
       ),
       NonEmptyChain.of(
@@ -83,6 +86,7 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
   override def calculateIntegrationTime(
     target:        TargetData,
+    atWavelength:  Wavelength,
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
@@ -97,6 +101,7 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
   override def calculateGraph(
     target:        TargetData,
+    atWavelength:  Wavelength,
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
@@ -141,6 +146,7 @@ object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
   override def calculateIntegrationTime(
     target:        TargetData,
+    atWavelength:  Wavelength,
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
@@ -150,6 +156,7 @@ object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
   override def calculateGraph(
     target:        TargetData,
+    atWavelength:  Wavelength,
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,

--- a/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
@@ -32,7 +32,8 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
-    signalToNoise: SignalToNoise
+    signalToNoise: SignalToNoise,
+    wavelength:    Wavelength
   ): IO[NonEmptyChain[IntegrationTime]] =
     NonEmptyChain
       .of(IntegrationTime(TimeSpan.fromSeconds(1).get, 10.refined, SignalToNoise.fromInt(10).get))
@@ -44,7 +45,8 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
     exposureTime:  TimeSpan,
-    exposureCount: PosInt
+    exposureCount: PosInt,
+    wavelength:    Wavelength
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(
@@ -86,7 +88,8 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
-    signalToNoise: SignalToNoise
+    signalToNoise: SignalToNoise,
+    wavelength:    Wavelength
   ): IO[NonEmptyChain[IntegrationTime]] =
     NonEmptyChain
       .of(
@@ -101,7 +104,8 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
     exposureTime:  TimeSpan,
-    exposureCount: PosInt
+    exposureCount: PosInt,
+    wavelength:    Wavelength
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(
@@ -144,7 +148,8 @@ object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
-    signalToNoise: SignalToNoise
+    signalToNoise: SignalToNoise,
+    wavelength:    Wavelength
   ): IO[NonEmptyChain[IntegrationTime]] =
     IO.raiseError(CalculationError("A calculation error"))
 
@@ -154,7 +159,8 @@ object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
     exposureTime:  TimeSpan,
-    exposureCount: PosInt
+    exposureCount: PosInt,
+    wavelength:    Wavelength
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(

--- a/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
@@ -32,8 +32,7 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
-    signalToNoise: SignalToNoise,
-    wavelength:    Wavelength
+    signalToNoise: SignalToNoise
   ): IO[NonEmptyChain[IntegrationTime]] =
     NonEmptyChain
       .of(IntegrationTime(TimeSpan.fromSeconds(1).get, 10.refined, SignalToNoise.fromInt(10).get))
@@ -45,8 +44,7 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
     exposureTime:  TimeSpan,
-    exposureCount: PosInt,
-    wavelength:    Wavelength
+    exposureCount: PosInt
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(
@@ -88,8 +86,7 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
-    signalToNoise: SignalToNoise,
-    wavelength:    Wavelength
+    signalToNoise: SignalToNoise
   ): IO[NonEmptyChain[IntegrationTime]] =
     NonEmptyChain
       .of(
@@ -104,8 +101,7 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
     exposureTime:  TimeSpan,
-    exposureCount: PosInt,
-    wavelength:    Wavelength
+    exposureCount: PosInt
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(
@@ -148,8 +144,7 @@ object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     band:          Band,
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
-    signalToNoise: SignalToNoise,
-    wavelength:    Wavelength
+    signalToNoise: SignalToNoise
   ): IO[NonEmptyChain[IntegrationTime]] =
     IO.raiseError(CalculationError("A calculation error"))
 
@@ -159,8 +154,7 @@ object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     observingMode: ObservingMode,
     constraints:   ItcObservingConditions,
     exposureTime:  TimeSpan,
-    exposureCount: PosInt,
-    wavelength:    Wavelength
+    exposureCount: PosInt
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(

--- a/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
@@ -27,7 +27,7 @@ import lucuma.refined.*
 
 object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
-  override def calculateExposureTime(
+  override def calculateIntegrationTime(
     target:        TargetData,
     band:          Band,
     observingMode: ObservingMode,
@@ -81,7 +81,7 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
 object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
-  override def calculateExposureTime(
+  override def calculateIntegrationTime(
     target:        TargetData,
     band:          Band,
     observingMode: ObservingMode,
@@ -139,7 +139,7 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
 object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
-  override def calculateExposureTime(
+  override def calculateIntegrationTime(
     target:        TargetData,
     band:          Band,
     observingMode: ObservingMode,

--- a/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
@@ -27,26 +27,24 @@ import lucuma.refined.*
 
 object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
-  override def calculateIntegrationTime(
-    target:          TargetData,
-    band:            Band,
-    observingMode:   ObservingMode,
-    constraints:     ItcObservingConditions,
-    signalToNoise:   SignalToNoise,
-    signalToNoiseAt: Option[Wavelength]
+  override def calculateExposureTime(
+    target:        TargetData,
+    band:          Band,
+    observingMode: ObservingMode,
+    constraints:   ItcObservingConditions,
+    signalToNoise: SignalToNoise
   ): IO[NonEmptyChain[IntegrationTime]] =
     NonEmptyChain
       .of(IntegrationTime(TimeSpan.fromSeconds(1).get, 10.refined, SignalToNoise.fromInt(10).get))
       .pure[IO]
 
   override def calculateGraph(
-    target:          TargetData,
-    band:            Band,
-    observingMode:   ObservingMode,
-    constraints:     ItcObservingConditions,
-    exposureTime:    TimeSpan,
-    exposureCount:   PosInt,
-    signalToNoiseAt: Option[Wavelength]
+    target:        TargetData,
+    band:          Band,
+    observingMode: ObservingMode,
+    constraints:   ItcObservingConditions,
+    exposureTime:  TimeSpan,
+    exposureCount: PosInt
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(
@@ -83,13 +81,12 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
 object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
-  override def calculateIntegrationTime(
-    target:          TargetData,
-    band:            Band,
-    observingMode:   ObservingMode,
-    constraints:     ItcObservingConditions,
-    signalToNoise:   SignalToNoise,
-    signalToNoiseAt: Option[Wavelength]
+  override def calculateExposureTime(
+    target:        TargetData,
+    band:          Band,
+    observingMode: ObservingMode,
+    constraints:   ItcObservingConditions,
+    signalToNoise: SignalToNoise
   ): IO[NonEmptyChain[IntegrationTime]] =
     NonEmptyChain
       .of(
@@ -99,26 +96,26 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
       .pure[IO]
 
   override def calculateGraph(
-    target:          TargetData,
-    band:            Band,
-    observingMode:   ObservingMode,
-    constraints:     ItcObservingConditions,
-    exposureTime:    TimeSpan,
-    exposureCount:   PosInt,
-    signalToNoiseAt: Option[Wavelength]
+    target:        TargetData,
+    band:          Band,
+    observingMode: ObservingMode,
+    constraints:   ItcObservingConditions,
+    exposureTime:  TimeSpan,
+    exposureCount: PosInt
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(
-        ItcCcd(1,
-               1,
-               2,
-               2,
-               Wavelength.fromIntNanometers(1001).get,
-               Wavelength.fromIntNanometers(1001).get,
-               3,
-               4,
-               5,
-               Nil
+        ItcCcd(
+          1,
+          1,
+          2,
+          2,
+          Wavelength.fromIntNanometers(1001).get,
+          Wavelength.fromIntNanometers(1001).get,
+          3,
+          4,
+          5,
+          Nil
         )
       ),
       NonEmptyChain.of(
@@ -142,37 +139,36 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
 object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
 
-  override def calculateIntegrationTime(
-    target:          TargetData,
-    band:            Band,
-    observingMode:   ObservingMode,
-    constraints:     ItcObservingConditions,
-    signalToNoise:   SignalToNoise,
-    signalToNoiseAt: Option[Wavelength]
+  override def calculateExposureTime(
+    target:        TargetData,
+    band:          Band,
+    observingMode: ObservingMode,
+    constraints:   ItcObservingConditions,
+    signalToNoise: SignalToNoise
   ): IO[NonEmptyChain[IntegrationTime]] =
     IO.raiseError(CalculationError("A calculation error"))
 
   override def calculateGraph(
-    target:          TargetData,
-    band:            Band,
-    observingMode:   ObservingMode,
-    constraints:     ItcObservingConditions,
-    exposureTime:    TimeSpan,
-    exposureCount:   PosInt,
-    signalToNoiseAt: Option[Wavelength]
+    target:        TargetData,
+    band:          Band,
+    observingMode: ObservingMode,
+    constraints:   ItcObservingConditions,
+    exposureTime:  TimeSpan,
+    exposureCount: PosInt
   ): IO[TargetGraphsCalcResult] =
     TargetGraphsCalcResult(
       NonEmptyChain.of(
-        ItcCcd(1,
-               1,
-               2,
-               2,
-               Wavelength.fromIntNanometers(1001).get,
-               Wavelength.fromIntNanometers(1001).get,
-               3,
-               4,
-               5,
-               Nil
+        ItcCcd(
+          1,
+          1,
+          2,
+          2,
+          Wavelength.fromIntNanometers(1001).get,
+          Wavelength.fromIntNanometers(1001).get,
+          3,
+          4,
+          5,
+          Nil
         )
       ),
       NonEmptyChain.of(

--- a/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
@@ -20,12 +20,11 @@ import lucuma.itc.ItcGraphGroup
 import lucuma.itc.ItcObservingConditions
 import lucuma.itc.ItcSeries
 import lucuma.itc.SeriesDataType
-import lucuma.itc.SignalToNoiseCalculation
 import lucuma.itc.search.ObservingMode
 import lucuma.itc.search.TargetData
 import lucuma.refined.*
 
-object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
+object MockItc extends Itc[IO]:
 
   override def calculateIntegrationTime(
     target:        TargetData,
@@ -82,7 +81,7 @@ object MockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     )
       .pure[IO]
 
-object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
+object MockImagingItc extends Itc[IO]:
 
   override def calculateIntegrationTime(
     target:        TargetData,
@@ -142,7 +141,7 @@ object MockImagingItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
     )
       .pure[IO]
 
-object FailingMockItc extends Itc[IO] with SignalToNoiseCalculation[IO]:
+object FailingMockItc extends Itc[IO]:
 
   override def calculateIntegrationTime(
     target:        TargetData,


### PR DESCRIPTION
Namely, for inputs:

- `wavelength` is now `centralWavelength` and has been moved inside `mode` (only for spectroscopy, it's not required for imaging).
- `signalToNoiseAt` is now `atWavelength` and is mandatory instead of optional.

Code that only ran when `signalToNoiseAt` was absent has been removed.