### PR TITLE
Custom SED - Step 1

### DIFF
--- a/modules/service/src/main/scala/lucuma/itc/input/odb/FluxDensityInput.scala
+++ b/modules/service/src/main/scala/lucuma/itc/input/odb/FluxDensityInput.scala
@@ -16,7 +16,7 @@ object FluxDensityInput {
   val Binding: Matcher[(Wavelength, PosBigDecimal)] =
     ObjectFieldsBinding.rmap {
       case List(
-            WavelengthInput.Binding("wavelenth", rWavelength),
+            WavelengthInput.Binding("wavelength", rWavelength),
             BigDecimalBinding("density", rDensity)
           ) =>
         (rWavelength, rDensity).parTupled.flatMap { case (wavelength, density) =>

--- a/modules/service/src/main/scala/lucuma/itc/legacy/codecs.scala
+++ b/modules/service/src/main/scala/lucuma/itc/legacy/codecs.scala
@@ -218,30 +218,41 @@ private given Encoder[SourceProfile] = (a: SourceProfile) =>
 private given Encoder[UnnormalizedSED] = (a: UnnormalizedSED) =>
   import UnnormalizedSED.*
   a match
-    case BlackBody(t)       =>
+    case BlackBody(t)               =>
       Json.obj(
         "BlackBody" -> Json.obj(
           "temperature" -> Json.fromDoubleOrNull(t.value.value.toDouble)
         )
       )
-    case PowerLaw(i)        =>
+    case PowerLaw(i)                =>
       Json.obj("PowerLaw" -> Json.obj("index" -> Json.fromDoubleOrNull(i.toDouble)))
-    case StellarLibrary(s)  =>
+    case StellarLibrary(s)          =>
       Json.obj("Library" -> Json.obj("LibraryStar" -> Json.fromString(s.ocs2Tag)))
-    case s: CoolStarModel   =>
+    case s: CoolStarModel           =>
       Json.obj("Library" -> Json.obj("LibraryStar" -> Json.fromString(s.ocs2Tag)))
-    case PlanetaryNebula(s) =>
+    case PlanetaryNebula(s)         =>
       Json.obj("Library" -> Json.obj("LibraryStar" -> Json.fromString(s.ocs2Tag)))
-    case Galaxy(s)          =>
+    case Galaxy(s)                  =>
       Json.obj("Library" -> Json.obj("LibraryNonStar" -> Json.fromString(s.ocs2Tag)))
-    case Planet(s)          =>
+    case Planet(s)                  =>
       Json.obj("Library" -> Json.obj("LibraryNonStar" -> Json.fromString(s.ocs2Tag)))
-    case HIIRegion(s)       =>
+    case HIIRegion(s)               =>
       Json.obj("Library" -> Json.obj("LibraryNonStar" -> Json.fromString(s.ocs2Tag)))
-    case Quasar(s)          =>
+    case Quasar(s)                  =>
       Json.obj("Library" -> Json.obj("LibraryNonStar" -> Json.fromString(s.ocs2Tag)))
-    case _                  => // TODO UserDefined
-      Json.obj("Library" -> Json.Null)
+    case UserDefined(fluxDensities) =>
+      Json.obj(
+        "UserDefined" -> Json.obj(
+          "UserDefinedSpectrum" -> Json.obj(
+            "name"     -> Json.fromString("UserDefined"),
+            "spectrum" -> Json.fromString:
+              fluxDensities.toNel.toList
+                .map: (w, f) =>
+                  s"${w.toNanometers} ${f.value}"
+                .mkString("\n")
+          )
+        )
+      )
 
 private given Encoder[Band] =
   Encoder[String].contramap(_.shortName)

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLCustomSedSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLCustomSedSuite.scala
@@ -3,12 +3,7 @@
 
 package lucuma.itc.service
 
-import cats.syntax.all.*
 import io.circe.literal.*
-import lucuma.core.enums.*
-import lucuma.core.syntax.string.*
-import lucuma.core.util.Enumerated
-import lucuma.itc.ItcObservingConditions
 
 class GraphQLCustomSedSuite extends GraphQLSuite {
 

--- a/modules/tests/src/test/scala/lucuma/itc/service/GraphQLCustomSedSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/service/GraphQLCustomSedSuite.scala
@@ -1,0 +1,129 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.itc.service
+
+import cats.syntax.all.*
+import io.circe.literal.*
+import lucuma.core.enums.*
+import lucuma.core.syntax.string.*
+import lucuma.core.util.Enumerated
+import lucuma.itc.ItcObservingConditions
+
+class GraphQLCustomSedSuite extends GraphQLSuite {
+
+  test("custom sed integration time") {
+    query(
+      """
+        query {
+          spectroscopyIntegrationTime(input: {
+            exposureTimeMode: {
+              signalToNoise: {
+                value: 2,
+                at: { nanometers: 600 }
+              }
+            },
+            asterism: [
+              {
+                sourceProfile: {
+                  point: {
+                    bandNormalized: {
+                      sed: {
+                        fluxDensities: [
+                          { wavelength: { nanometers: 500.0 }, density: 1.0 },
+                          { wavelength: { nanometers: 600.0 }, density: 2.0 },
+                          { wavelength: { nanometers: 700.0 }, density: 3.0 }
+                        ]
+                      }
+                      brightnesses: [{
+                        band: R
+                        value: 9
+                        units: VEGA_MAGNITUDE
+                      }]
+                    }
+                  }
+                },
+                radialVelocity: {
+                  kilometersPerSecond: 1000
+                }
+              }
+            ],
+            constraints: {
+              imageQuality: POINT_EIGHT,
+              cloudExtinction: ONE_POINT_FIVE,
+              skyBackground: BRIGHT,
+              waterVapor: MEDIAN,
+              elevationRange: {
+                airMass: {
+                  min: 1,
+                  max: 2
+                }
+              }
+            },
+            mode: {
+              gmosNSpectroscopy: {
+                centralWavelength: {
+                  nanometers: 60
+                },
+                filter: GG455,
+                fpu: {
+                  builtin: LONG_SLIT_0_25
+                },
+                grating: B1200_G5301
+              }
+            }
+          }) {
+            mode {
+              ... on SpectroscopyMode {
+                instrument
+                params {
+                  ... on GmosNITCParams {
+                    grating
+                  }
+                }
+                centralWavelength {
+                  nanometers
+                }
+              }
+            }
+            brightest {
+              selected {
+                exposureCount
+                exposureTime {
+                  seconds
+                }
+              }
+              band
+            }
+          }
+        }
+      """,
+      json"""
+        {
+          "data": {
+            "spectroscopyIntegrationTime" : {
+              "mode" : {
+                "instrument" : "GMOS_NORTH",
+                "params": {
+                  "grating": "B1200_G5301"
+                },
+                "centralWavelength" : {
+                  "nanometers" : 60.000
+                }
+              },
+              "brightest": {
+                "selected" : {
+                  "exposureCount" : 10,
+                  "exposureTime" : {
+                    "seconds" : 1.000000
+                  }
+                },
+                "band": "R"
+              }
+            }
+          }
+        }
+        """
+    )
+  }
+}

--- a/modules/tests/src/test/scala/lucuma/itc/tests/LegacyITCSignalToNoiseSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/tests/LegacyITCSignalToNoiseSuite.scala
@@ -3,10 +3,12 @@
 
 package lucuma.itc
 
+import cats.data.NonEmptyMap
 import cats.implicits.*
 import coulomb.*
 import coulomb.syntax.*
 import coulomb.units.si.*
+import eu.timepit.refined.types.numeric.PosBigDecimal
 import eu.timepit.refined.types.numeric.PosInt
 import io.circe.syntax.*
 import lucuma.core.enums.*
@@ -40,7 +42,7 @@ import scala.collection.immutable.SortedMap
  * legacy ITC (Note that the ITC may still return an error but we want to ensure it can parse the
  * values
  */
-class LegacyITCSignalToNiseSuite extends FunSuite with CommonITCSuite:
+class LegacyITCSignalToNoiseSuite extends FunSuite with CommonITCSuite:
 
   val sourceDefinition = ItcSourceDefinition(
     TargetData(
@@ -85,21 +87,23 @@ class LegacyITCSignalToNiseSuite extends FunSuite with CommonITCSuite:
       GmosNorthGrating.B1200_G5301,
       GmosNorthFpuParam(GmosNorthFpu.LongSlit_5_00),
       none,
-      GmosCcdMode(GmosXBinning.One,
-                  GmosYBinning.One,
-                  GmosAmpCount.Twelve,
-                  GmosAmpGain.High,
-                  GmosAmpReadMode.Fast
+      GmosCcdMode(
+        GmosXBinning.One,
+        GmosYBinning.One,
+        GmosAmpCount.Twelve,
+        GmosAmpGain.High,
+        GmosAmpReadMode.Fast
       ).some,
       GmosRoi.FullFrame.some
     )
   )
 
-  val conditions = ItcObservingConditions(ImageQuality.PointEight,
-                                          CloudExtinction.OnePointFive,
-                                          WaterVapor.Median,
-                                          SkyBackground.Bright,
-                                          1
+  val conditions = ItcObservingConditions(
+    ImageQuality.PointEight,
+    CloudExtinction.OnePointFive,
+    WaterVapor.Median,
+    SkyBackground.Bright,
+    1
   )
 
   def bodyCond(c: ItcObservingConditions) =
@@ -321,6 +325,22 @@ class LegacyITCSignalToNiseSuite extends FunSuite with CommonITCSuite:
           bodyIntMagUnits(f.withValueTagged(BrightnessValue.unsafeFrom(5))).asJson.noSpaces
         )
       assert(result.fold(allowedErrors, _ => true))
+
+  test("user defined SED".tag(LocalOnly)) {
+    val userDefinedFluxDensities = NonEmptyMap.of(
+      Wavelength.decimalNanometers.getOption(500).get -> PosBigDecimal.unsafeFrom(1.0),
+      Wavelength.decimalNanometers.getOption(600).get -> PosBigDecimal.unsafeFrom(2.0),
+      Wavelength.decimalNanometers.getOption(700).get -> PosBigDecimal.unsafeFrom(3.0)
+    )
+
+    val result = localItc
+      .calculateIntegrationTime(
+        bodySED(UnnormalizedSED.UserDefined(userDefinedFluxDensities)).asJson.noSpaces
+      )
+
+    println(result)
+    assert(result.fold(allowedErrors, _ => true))
+  }
 
   def bodySurfaceMagUnits(c: BrightnessMeasure[Surface]) =
     ItcParameters(

--- a/modules/tests/src/test/scala/lucuma/itc/tests/LegacyITCSignalToNoiseSuite.scala
+++ b/modules/tests/src/test/scala/lucuma/itc/tests/LegacyITCSignalToNoiseSuite.scala
@@ -338,7 +338,6 @@ class LegacyITCSignalToNoiseSuite extends FunSuite with CommonITCSuite:
         bodySED(UnnormalizedSED.UserDefined(userDefinedFluxDensities)).asJson.noSpaces
       )
 
-    println(result)
     assert(result.fold(allowedErrors, _ => true))
   }
 


### PR DESCRIPTION
This PR provides both correct decoding of inputs and old-ITC encoding to support custom SEDs.

The final goal here is for clients to be able to provide the custom SED as a URL and the ITC server will read an cache the contents. A last-updated timestamp will be passed by clients too. If changed from last invocation, it will invalidate the cache. Old-ITC will always be invoked with the custom SED in a string (the encoding of which is provided in this PR).

I'll break the implementation of all this into smaller, hopefully more digestible, PRs.