### PR TITLE
Allow to use no redis locally for testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -163,8 +163,7 @@ lazy val service = project
       "-Dcats.effect.tracing.mode=none"
     ),
     reStart / envVars     := Map(
-      "REDISCLOUD_URL" -> "redis://localhost",
-      "ODB_BASE_URL"   -> "https://lucuma-postgres-odb-dev.herokuapp.com"
+      "ODB_BASE_URL" -> "https://lucuma-postgres-odb-dev.herokuapp.com"
     ),
     libraryDependencies ++= Seq(
       "org.typelevel"     %% "grackle-core"          % grackleVersion,

--- a/modules/service/src/main/scala/lucuma/itc/cache/NoOpBinaryCache.scala
+++ b/modules/service/src/main/scala/lucuma/itc/cache/NoOpBinaryCache.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.itc.cache
+
+import cats.Applicative
+import cats.effect.Async
+import cats.syntax.all.*
+import io.chrisdavenport.keysemaphore.KeySemaphore
+import natchez.Trace
+import org.typelevel.log4cats.Logger
+
+import scala.concurrent.duration.FiniteDuration
+
+object NoOpBinaryCache:
+
+  def apply[F[_]: Async: Trace: Logger]: F[BinaryEffectfulCache[F]] =
+    KeySemaphore
+      .of[F, Array[Byte]](_ => 1)
+      .map: sem =>
+        new BinaryEffectfulCache[F] {
+
+          override protected val keySemaphore: KeySemaphore[F, Array[Byte]] =
+            sem
+
+          protected def read(key: Array[Byte]): F[Option[Array[Byte]]] =
+            none.pure[F]
+
+          protected def write(
+            key:   Array[Byte],
+            value: Array[Byte],
+            ttl:   Option[FiniteDuration]
+          ): F[Unit] =
+            Applicative[F].unit
+
+          def flush: F[Unit] =
+            Applicative[F].unit
+        }


### PR DESCRIPTION
For a while, I have wanted the option to run ITC with a simulated Redis. It will force to have a Redis instance while running in Heroku though. 