### PR TITLE
Use percentage of memory for java settings rather than absolute values

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -232,8 +232,8 @@ lazy val deployedAppSettings = Seq(
   // Launch options
   Universal / javaOptions ++= Seq(
     // -J params will be added as jvm parameters
-    "-J-Xmx1024m",
-    "-J-Xms256m",
+    "-J-XX:MinRAMPercentage=80",
+    "-J-XX:MaxRAMPercentage=80",
     // Support remote JMX access
     "-J-Dcom.sun.management.jmxremote",
     "-J-Dcom.sun.management.jmxremote.authenticate=false",


### PR DESCRIPTION
ITC dev is still running out of memory on Heroku with the max memory size set the same as the dyno memory size. After some research I found the when running in a docker container, you can use memory percentages via `-XX:[Min,Max]RAMPercentage` instead of absolute sizes and this is recommended for running in containers.

Also, instead of setting an initial and a maximum setting, I set the min and max to be the same. This purportedly can boost performance...

I am initially setting it to use 80% of the available memory, but we may be able to go higher since it is the only think running on the dyno. I figure we can watch the memory usage and increase if it seems good.