### PR TITLE
Back to explicit memory settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -232,8 +232,8 @@ lazy val deployedAppSettings = Seq(
   // Launch options
   Universal / javaOptions ++= Seq(
     // -J params will be added as jvm parameters
-    "-J-XX:MinRAMPercentage=80",
-    "-J-XX:MaxRAMPercentage=80",
+    "-J-Xmx768m",
+    "-J-Xms256m",
     // Support remote JMX access
     "-J-Dcom.sun.management.jmxremote",
     "-J-Dcom.sun.management.jmxremote.authenticate=false",


### PR DESCRIPTION
The percentage memory allocation should work if Heroku is setting the maximum size for the docker image on the run command. However, it doesn't seem to be doing that. So, I'm back to explicit memory but a smaller max size. 🤷 

Instead of just `R14 (memory quota exceeded)` errors, we were getting `Error R15 (Memory quota vastly exceeded)` errors. Yay for us!