### PR TITLE
Reduce heap to 512M

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -232,7 +232,7 @@ lazy val deployedAppSettings = Seq(
   // Launch options
   Universal / javaOptions ++= Seq(
     // -J params will be added as jvm parameters
-    "-J-Xmx768m",
+    "-J-Xmx512m",
     "-J-Xms256m",
     // Support remote JMX access
     "-J-Dcom.sun.management.jmxremote",


### PR DESCRIPTION
Even at 768m on a 1024m dyno, we were getting `R14 (memory quota exceeded)` errors.

My latest theory is that it is related to the JVM tricks to use the old ITC jar files. Perhaps they are greatly increasing the `metaspace` requirements of the app. The total size of all the jar files is 367m, with a single one being 353m all by itself.

We'll see if a 512m heap allocation solves the problem. It was running in a dyno with a total of 512 before the docker changes, so it should be sufficient memory, but probably not optimal.