### PR TITLE
Reduce MaxRAMPercentage to 50%

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -235,8 +235,7 @@ lazy val deployedAppSettings = Seq(
     // The heap needs to be a lot smaller than the dyno size. This may be
     // because the JVM tricks to load the 367M of old itc jar files increases the
     // `metaspace` size by that amount. It's a nice theory, at least.
-    "-J-XX:MinRAMPercentage=80",
-    "-J-XX:MaxRAMPercentage=80",
+    "-J-XX:MaxRAMPercentage=50",
     // Support remote JMX access
     "-J-Dcom.sun.management.jmxremote",
     "-J-Dcom.sun.management.jmxremote.authenticate=false",


### PR DESCRIPTION
`MinRAMPercentage` name is misleading. This is the setting used when running is small memory environments of -200M, while `MaxRAMPercentage` is used for larger memory environments.

We were blowing through the dyno memory, so I'm trying to reduce it to 50% and see what happens...