### PR TITLE
Push image for all environments on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,10 @@ jobs:
         run: |
           npm install -g heroku
           heroku container:login
-          docker tag noirlab/gpp-itc registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc-dev' }}/web
-          docker push registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc-dev' }}/web
-          heroku container:release web -a ${{ vars.HEROKU_APP_NAME || 'itc-dev' }} -v
+          docker tag noirlab/gpp-itc registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc' }}-dev/web
+          docker push registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc' }}-dev/web
+          docker tag noirlab/gpp-itc registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc' }}-staging/web
+          docker push registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc' }}-staging/web
+          docker tag noirlab/gpp-itc registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc' }}-production/web
+          docker push registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc' }}-production/web
+          heroku container:release web -a ${{ vars.HEROKU_APP_NAME || 'itc' }}-dev -v

--- a/build.sbt
+++ b/build.sbt
@@ -80,15 +80,21 @@ lazy val sbtDockerPublishLocal =
     name = Some("Build and Publish Docker image")
   )
 
+val environments = List("dev", "staging", "production")
+
 lazy val herokuRelease =
   WorkflowStep.Run(
     List(
       "npm install -g heroku",
-      "heroku container:login",
-      "docker tag noirlab/gpp-itc registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc-dev' }}/web",
-      "docker push registry.heroku.com/${{ vars.HEROKU_APP_NAME || 'itc-dev' }}/web",
-      "heroku container:release web -a ${{ vars.HEROKU_APP_NAME || 'itc-dev' }} -v"
-    ),
+      "heroku container:login"
+    ) ++
+      environments.flatMap(env =>
+        List(
+          s"docker tag noirlab/gpp-itc registry.heroku.com/$${{ vars.HEROKU_APP_NAME || 'itc' }}-${env}/web",
+          s"docker push registry.heroku.com/$${{ vars.HEROKU_APP_NAME || 'itc' }}-${env}/web"
+        )
+      ) :+
+      s"heroku container:release web -a $${{ vars.HEROKU_APP_NAME || 'itc' }}-${environments.head} -v",
     name = Some("Deploy and release app in Heroku")
   )
 


### PR DESCRIPTION
This avoids the need to pull, retag and push back images on promotion.

Promotion just becomes an issue of releasing the latest image for a given environment.

Although technically it's not a promotion anymore, it should speed it up dramatically.